### PR TITLE
fix: improve security and health check output

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -157,6 +157,8 @@ Both Docker Desktop and Podman work on all platforms (macOS, Linux).
 
 - Basic auth enabled by default (use `--no-auth` to disable for local dev)
 - Basic auth over HTTPS required for production
+- **ttyd binds to localhost only** - external access via tmux-api proxy (handles auth)
+- tmux-api binds to localhost by default, use `--lan` to expose to network
 - Same-origin iframe setup via tmux-api proxy
 - PostMessage uses explicit origin (not wildcard)
 - Exclude sensitive dirs (.ssh, .gnupg) from volume mounts

--- a/scripts/get.sh
+++ b/scripts/get.sh
@@ -104,9 +104,23 @@ main() {
     rm -f "$TARBALL"
 
     # Run termote CLI with forwarded arguments
+    # Default to native mode if no mode specified (allows host tool access like claude, gh)
     info "Running installer..."
     chmod +x scripts/termote.sh
-    ./scripts/termote.sh install "$@"
+
+    local mode=""
+    local args=()
+    for arg in "$@"; do
+        case "$arg" in
+            container|native) mode="$arg" ;;
+            *) args+=("$arg") ;;
+        esac
+    done
+
+    # Default to native if no mode specified
+    [[ -z "$mode" ]] && mode="native"
+
+    ./scripts/termote.sh install "$mode" "${args[@]}"
 }
 
 main "$@"

--- a/scripts/termote.sh
+++ b/scripts/termote.sh
@@ -20,6 +20,7 @@ ARCH="$(case "$(uname -m)" in x86_64|amd64) echo amd64;; aarch64|arm64) echo arm
 # Constants
 PORT_MAIN=7680
 PORT_TTYD=7681
+CONTAINER_NAME="termote"
 
 # =============================================================================
 # COLORS & UI
@@ -78,12 +79,13 @@ get_lan_ip() {
 }
 
 start_ttyd() {
+    # Always bind ttyd to localhost - external access via tmux-api proxy only
     local ttyd_ver
     ttyd_ver=$(ttyd --version 2>&1 | grep -oE '[0-9]+\.[0-9]+' | head -1)
     if [[ "$(printf '%s\n' "1.7" "$ttyd_ver" | sort -V | head -1)" == "1.7" ]]; then
-        nohup ttyd -W -p $PORT_TTYD tmux new-session -A -s main > /dev/null 2>&1 &
+        nohup ttyd -W -i lo -p $PORT_TTYD tmux new-session -A -s main > /dev/null 2>&1 &
     else
-        nohup ttyd -p $PORT_TTYD tmux new-session -A -s main > /dev/null 2>&1 &
+        nohup ttyd -i lo -p $PORT_TTYD tmux new-session -A -s main > /dev/null 2>&1 &
     fi
     sleep 1
 }
@@ -477,37 +479,86 @@ cmd_health() {
     local failed=0
     local port="${PORT:-$PORT_MAIN}"
 
+    # Detect container mode (check if container is running)
+    local container_mode=false
+    local runtime=""
+    if [[ -n "$(docker ps -q --filter "name=$CONTAINER_NAME" 2>/dev/null)" ]]; then
+        container_mode=true; runtime="docker"
+    elif [[ -n "$(podman ps -q --filter "name=$CONTAINER_NAME" 2>/dev/null)" ]]; then
+        container_mode=true; runtime="podman"
+    fi
+
+    # Cache ss output once for bind info lookups
+    local ss_cache=$(ss -tlnp 2>/dev/null || true)
+
+    # Helper to format HTTP status
+    format_status() {
+        case "$1" in
+            000) echo "not running" ;;
+            200) echo "running" ;;
+            401) echo "running (auth)" ;;
+            *) echo "HTTP $1" ;;
+        esac
+    }
+
+    # Get bind info from cached ss output
+    get_bind_info() {
+        local p="$1"
+        local bind=$(echo "$ss_cache" | grep ":$p " | awk '{print $4}' | head -1)
+        if [[ "$bind" == "0.0.0.0:"* || "$bind" == "*:"* ]]; then
+            echo "LAN"
+        elif [[ -n "$bind" ]]; then
+            echo "localhost"
+        fi
+    }
+
     # Check ttyd
-    local status=$(curl -s -o /dev/null -w "%{http_code}" "http://127.0.0.1:$PORT_TTYD/" 2>/dev/null)
-    if [[ "$status" == "200" ]]; then
-        echo -e "  ${GREEN}[OK]${NC} ttyd (port $PORT_TTYD)"
+    if [[ "$container_mode" == true ]]; then
+        local status=$($runtime exec $CONTAINER_NAME curl -s -o /dev/null -w "%{http_code}" "http://127.0.0.1:$PORT_TTYD/" 2>/dev/null || true)
+        if [[ "$status" == "200" ]]; then
+            echo -e "  ${GREEN}[OK]${NC} ttyd :$PORT_TTYD - running (container)"
+        else
+            echo -e "  ${RED}[--]${NC} ttyd :$PORT_TTYD - $(format_status $status) (container)"
+            : $((failed++))
+        fi
     else
-        echo -e "  ${RED}[FAIL]${NC} ttyd (port $PORT_TTYD) - HTTP $status"
-        ((failed++))
+        local status=$(curl -s -o /dev/null -w "%{http_code}" "http://127.0.0.1:$PORT_TTYD/" 2>/dev/null || true)
+        local bind_ttyd=$(get_bind_info $PORT_TTYD)
+        local ttyd_info="$(format_status $status)"
+        [[ -n "$bind_ttyd" ]] && ttyd_info="$ttyd_info ($bind_ttyd)"
+        if [[ "$status" == "200" ]]; then
+            echo -e "  ${GREEN}[OK]${NC} ttyd :$PORT_TTYD - $ttyd_info"
+        else
+            echo -e "  ${RED}[--]${NC} ttyd :$PORT_TTYD - $ttyd_info"
+            : $((failed++))
+        fi
     fi
 
     # Check main server
-    status=$(curl -s -o /dev/null -w "%{http_code}" "http://localhost:$port/" 2>/dev/null)
+    status=$(curl -s -o /dev/null -w "%{http_code}" "http://localhost:$port/" 2>/dev/null || true)
+    local bind_api=$(get_bind_info $port)
+    local api_info="$(format_status $status)"
+    [[ -n "$bind_api" ]] && api_info="$api_info ($bind_api)"
     if [[ "$status" == "200" || "$status" == "401" ]]; then
-        echo -e "  ${GREEN}[OK]${NC} termote (port $port)"
+        echo -e "  ${GREEN}[OK]${NC} tmux-api :$port - $api_info"
     else
-        echo -e "  ${RED}[FAIL]${NC} termote (port $port) - HTTP $status"
-        ((failed++))
+        echo -e "  ${RED}[--]${NC} tmux-api :$port - $api_info"
+        : $((failed++))
     fi
 
-    # Check API
-    status=$(curl -s -o /dev/null -w "%{http_code}" "http://127.0.0.1:$port/api/tmux/health" 2>/dev/null)
+    # Check API endpoint
+    status=$(curl -s -o /dev/null -w "%{http_code}" "http://127.0.0.1:$port/api/tmux/health" 2>/dev/null || true)
     if [[ "$status" == "200" || "$status" == "401" ]]; then
-        echo -e "  ${GREEN}[OK]${NC} API (/api/tmux/health)"
+        echo -e "  ${GREEN}[OK]${NC} API /api/tmux/health - $(format_status $status)"
     else
-        echo -e "  ${YELLOW}[WARN]${NC} API - HTTP $status"
+        echo -e "  ${YELLOW}[--]${NC} API /api/tmux/health - $(format_status $status)"
     fi
 
     echo ""
     if [[ $failed -eq 0 ]]; then
         echo -e "${GREEN}All services healthy!${NC}"
     else
-        echo -e "${RED}$failed service(s) unhealthy${NC}"
+        echo -e "${YELLOW}$failed service(s) not running${NC}"
         exit 1
     fi
 }

--- a/tests/test-get.sh
+++ b/tests/test-get.sh
@@ -200,11 +200,18 @@ test_install_script_call() {
         fail "termote.sh install" "present" "not found"
     fi
 
-    # Verify arguments are forwarded
-    if grep -q 'install "\$@"' "$PROJECT_DIR/scripts/get.sh"; then
-        pass "forwards arguments to termote.sh"
+    # Verify default mode is native
+    if grep -q 'mode="native"' "$PROJECT_DIR/scripts/get.sh"; then
+        pass "default mode is native"
     else
-        fail "arg forwarding" '$@' "not found"
+        fail "default mode" "native" "not found"
+    fi
+
+    # Verify mode extraction from args
+    if grep -q 'container|native) mode=' "$PROJECT_DIR/scripts/get.sh"; then
+        pass "mode extraction from args"
+    else
+        fail "mode extraction" "case pattern" "not found"
     fi
 }
 

--- a/tests/test-termote.sh
+++ b/tests/test-termote.sh
@@ -223,6 +223,56 @@ test_security() {
     else
         fail "password input" "read -s" "not found"
     fi
+
+    # Verify ttyd binds to localhost only
+    if grep -q '\-i lo' "$SCRIPT"; then
+        pass "ttyd binds to localhost only (-i lo)"
+    else
+        fail "ttyd binding" "-i lo" "not found"
+    fi
+}
+
+# =============================================================================
+# HEALTH CHECK TESTS
+# =============================================================================
+test_health_check() {
+    echo ""
+    echo "=== Health Check ==="
+
+    # Verify CONTAINER_NAME constant
+    if grep -q 'CONTAINER_NAME=' "$SCRIPT"; then
+        pass "CONTAINER_NAME constant defined"
+    else
+        fail "CONTAINER_NAME" "constant" "not found"
+    fi
+
+    # Verify container mode detection
+    if grep -q 'container_mode=false' "$SCRIPT" && grep -q 'container_mode=true' "$SCRIPT"; then
+        pass "container mode detection"
+    else
+        fail "container detection" "container_mode var" "not found"
+    fi
+
+    # Verify format_status helper
+    if grep -q 'format_status()' "$SCRIPT"; then
+        pass "format_status helper present"
+    else
+        fail "format_status" "function" "not found"
+    fi
+
+    # Verify ss output caching
+    if grep -q 'ss_cache=' "$SCRIPT"; then
+        pass "ss output cached for efficiency"
+    else
+        fail "ss caching" "ss_cache var" "not found"
+    fi
+
+    # Verify health output shows LAN/localhost
+    if grep -q 'LAN' "$SCRIPT" && grep -q 'localhost' "$SCRIPT"; then
+        pass "health shows bind info (LAN/localhost)"
+    else
+        fail "bind info" "LAN/localhost" "not found"
+    fi
 }
 
 # =============================================================================
@@ -240,6 +290,7 @@ test_docker_compose
 test_interactive
 test_entrypoints
 test_security
+test_health_check
 
 # Summary
 echo ""


### PR DESCRIPTION
## Summary
- **Security**: ttyd binds to localhost only (`-i lo`), external access via tmux-api proxy
- **Fix**: get.sh defaults to native mode when no mode specified
- **Improve**: health check shows LAN/localhost bind info and container mode
- **Improve**: clearer status messages (running, not running, auth)
- **Refactor**: add CONTAINER_NAME constant, cache ss output
- **Test**: add unit tests for new features (55 tests pass)
- **Docs**: update CLAUDE.md security notes

## Test plan
- [x] `make test` passes (55 tests)
- [x] Health check works in container mode
- [x] Health check works in native mode
- [x] `curl ... get.sh | bash` defaults to native mode
- [x] ttyd only accessible via localhost