### PR TITLE
fix: resolve macOS shell compatibility and terminal artifacts

### DIFF
--- a/pwa/src/components/terminal-frame.tsx
+++ b/pwa/src/components/terminal-frame.tsx
@@ -1,5 +1,9 @@
 import { forwardRef, useEffect, useImperativeHandle, useRef } from 'react'
-import { setTerminalFontSize, setTerminalTheme } from '../utils/terminal-bridge'
+import {
+  sendKeyToTerminal,
+  setTerminalFontSize,
+  setTerminalTheme,
+} from '../utils/terminal-bridge'
 
 interface Props {
   fontSize?: number
@@ -75,6 +79,10 @@ export const TerminalFrame = forwardRef<HTMLIFrameElement, Props>(
         const themeApplied = setTerminalTheme(iframe, THEMES[theme])
         if (themeApplied) {
           setTerminalFontSize(iframe, fontSize)
+          // Clear DA response artifacts (e.g. "1;2c0;276;0c") leaked by xterm.js
+          // when ttyd+tmux connection is established. Ctrl+U clears the input line.
+          // Delay to ensure DA responses have arrived before clearing.
+          setTimeout(() => sendKeyToTerminal(iframe, 'u', true), 300)
           if (intervalId) clearInterval(intervalId)
         } else if (++attempts >= 30) {
           if (intervalId) clearInterval(intervalId)

--- a/scripts/termote.sh
+++ b/scripts/termote.sh
@@ -15,7 +15,14 @@ PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
 
 # Cached system info (computed once)
 OS="$(uname)"
-ARCH="$(case "$(uname -m)" in x86_64|amd64) echo amd64;; aarch64|arm64) echo arm64;; *) echo amd64;; esac)"
+_uname_m="$(uname -m)"
+if [ "$_uname_m" = "x86_64" ] || [ "$_uname_m" = "amd64" ]; then
+    ARCH="amd64"
+elif [ "$_uname_m" = "aarch64" ] || [ "$_uname_m" = "arm64" ]; then
+    ARCH="arm64"
+else
+    ARCH="amd64"
+fi
 
 # Constants
 PORT_MAIN=7680
@@ -284,8 +291,8 @@ select_with_gum() {
 
 select_with_bash() {
     local header="$1"; shift
-    echo "$header"
-    echo ""
+    echo "$header" >&2
+    echo "" >&2
     select choice in "$@"; do
         [[ -n "$choice" ]] && echo "$choice" && break
     done


### PR DESCRIPTION
## Summary
- Fix `termote.sh` syntax error on macOS bash 3.2 by replacing `case` inside `$()` with `if/elif`
- Fix interactive menu not responding to selection by redirecting header output to stderr
- Clear DA response text artifacts (`1;2c0;276;0c`) leaked on PWA terminal connect

## Test plan
- [ ] Run `./scripts/termote.sh` on macOS — verify no syntax error and menu selection works
- [ ] Run `curl ... | bash` installer — verify no syntax error
- [ ] Open PWA in browser — verify no DA response text visible in terminal