### PR TITLE
fix: add Darwin binaries for native mode on macOS

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -146,6 +146,34 @@ jobs:
           path: tmux-api/tmux-api-linux-arm64
           retention-days: 1
 
+  build-api-darwin:
+    name: Build API (darwin-${{ matrix.goarch }})
+    runs-on: ubuntu-latest
+    needs: [prepare]
+    strategy:
+      matrix:
+        goarch: [amd64, arm64]
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version: "1.26"
+          cache-dependency-path: tmux-api/go.mod
+
+      - name: Build
+        working-directory: tmux-api
+        run: |
+          CGO_ENABLED=0 GOOS=darwin GOARCH=${{ matrix.goarch }} \
+            go build -ldflags="-s -w" -o tmux-api-darwin-${{ matrix.goarch }} .
+
+      - name: Upload binary
+        uses: actions/upload-artifact@v7
+        with:
+          name: tmux-api-darwin-${{ matrix.goarch }}
+          path: tmux-api/tmux-api-darwin-${{ matrix.goarch }}
+          retention-days: 1
+
   # ─────────────────────────────────────────────────────────────
   # Docker Build & Push (depends on all builds)
   # ─────────────────────────────────────────────────────────────
@@ -230,7 +258,7 @@ jobs:
   release:
     name: Create GitHub Release
     runs-on: ubuntu-latest
-    needs: [prepare, docker]
+    needs: [prepare, docker, build-api-darwin]
     if: needs.prepare.outputs.dry_run != 'true'
     permissions:
       contents: write
@@ -257,6 +285,8 @@ jobs:
           # Copy binaries
           cp artifacts/tmux-api-linux-amd64/tmux-api-linux-amd64 release/
           cp artifacts/tmux-api-linux-arm64/tmux-api-linux-arm64 release/
+          cp artifacts/tmux-api-darwin-amd64/tmux-api-darwin-amd64 release/
+          cp artifacts/tmux-api-darwin-arm64/tmux-api-darwin-arm64 release/
           chmod +x release/tmux-api-*
 
           # Create tarball (all files needed for termote.sh)
@@ -264,9 +294,11 @@ jobs:
           cp -r scripts Makefile README.md termote-v${VERSION}/
           cp docker-compose.yml Dockerfile entrypoint.sh termote-v${VERSION}/
           cp -r artifacts/pwa-dist termote-v${VERSION}/pwa-dist
-          # Include pre-built binaries
+          # Include pre-built binaries (Linux for container, Darwin for native on macOS)
           cp artifacts/tmux-api-linux-amd64/tmux-api-linux-amd64 termote-v${VERSION}/
           cp artifacts/tmux-api-linux-arm64/tmux-api-linux-arm64 termote-v${VERSION}/
+          cp artifacts/tmux-api-darwin-amd64/tmux-api-darwin-amd64 termote-v${VERSION}/
+          cp artifacts/tmux-api-darwin-arm64/tmux-api-darwin-arm64 termote-v${VERSION}/
           tar czf release/termote-v${VERSION}.tar.gz termote-v${VERSION}
 
           # Copy CLI script standalone
@@ -287,6 +319,8 @@ jobs:
             release/pwa-dist-v${{ needs.prepare.outputs.version }}.zip
             release/tmux-api-linux-amd64
             release/tmux-api-linux-arm64
+            release/tmux-api-darwin-amd64
+            release/tmux-api-darwin-arm64
             release/termote.sh
             release/checksums.txt
 

--- a/scripts/termote.sh
+++ b/scripts/termote.sh
@@ -403,10 +403,21 @@ cmd_install() {
 
     # Setup API
     step "2/4" "Setting up tmux-api..."
-    if [[ "$RELEASE_MODE" == true ]] && [[ -f "$PROJECT_DIR/tmux-api-linux-$ARCH" ]]; then
-        mkdir -p "$PROJECT_DIR/tmux-api"
-        cp "$PROJECT_DIR/tmux-api-linux-$ARCH" "$PROJECT_DIR/tmux-api/tmux-api"
-        chmod +x "$PROJECT_DIR/tmux-api/tmux-api"
+    if [[ "$RELEASE_MODE" == true ]]; then
+        # Determine correct pre-built binary for the target
+        local api_os="linux"
+        if [[ "$mode" == "native" ]]; then
+            # Native mode: use host OS binary (darwin or linux)
+            api_os="$(echo "$OS" | tr '[:upper:]' '[:lower:]')"
+        fi
+        local prebuilt="$PROJECT_DIR/tmux-api-${api_os}-${ARCH}"
+        if [[ -f "$prebuilt" ]]; then
+            mkdir -p "$PROJECT_DIR/tmux-api"
+            cp "$prebuilt" "$PROJECT_DIR/tmux-api/tmux-api"
+            chmod +x "$PROJECT_DIR/tmux-api/tmux-api"
+        else
+            error "Pre-built binary not found: tmux-api-${api_os}-${ARCH}"
+        fi
     elif [[ ("$mode" == "container" || "$mode" == "docker") && "$OS" != "Linux" ]]; then
         (cd "$PROJECT_DIR/tmux-api" && CGO_ENABLED=0 GOOS=linux GOARCH="$ARCH" go build -ldflags="-s -w" -o tmux-api .)
     else


### PR DESCRIPTION
## Summary
- Add Darwin amd64/arm64 build matrix to release workflow (cross-compiled on ubuntu-latest)
- Include Darwin binaries in release tarball and GitHub release assets
- Fix `termote.sh` to select correct OS binary based on install mode (darwin for native, linux for container)
- Docker job no longer blocked on Darwin builds it doesn't use

## Root cause
Release workflow only built Linux binaries. When `get.sh` installs in native mode on macOS, `termote.sh` copied the Linux ELF binary which cannot execute on Darwin → `tmux-api` fails to start.

## Test plan
- [ ] Verify release workflow builds Darwin binaries successfully
- [ ] `curl ... | bash` on macOS → tmux-api starts and `make health` passes
- [ ] Container mode still works (uses Linux binaries)