### PR TITLE
fix: resolve empty LAN IP on macOS

### DIFF
--- a/scripts/termote.sh
+++ b/scripts/termote.sh
@@ -80,8 +80,11 @@ detect_container_runtime() {
 get_arch() { echo "$ARCH"; }
 
 get_lan_ip() {
-    hostname -I 2>/dev/null | awk '{print $1}' || \
-    ipconfig getifaddr en0 2>/dev/null || \
+    local ip
+    ip=$(hostname -I 2>/dev/null | awk '{print $1}')
+    [ -n "$ip" ] && echo "$ip" && return
+    ip=$(ipconfig getifaddr en0 2>/dev/null)
+    [ -n "$ip" ] && echo "$ip" && return
     echo "0.0.0.0"
 }
 


### PR DESCRIPTION
## Summary
- Fix `get_lan_ip()` returning empty string on macOS when using `--lan` flag
- `hostname -I | awk` pipe always exits 0 even with no output, preventing fallback to `ipconfig getifaddr en0`
- Now checks each result for non-empty before returning, ensuring correct fallback chain

## Test plan
- [ ] Run `./scripts/termote.sh install container --lan` on macOS — verify LAN IP is shown
- [ ] Run on Linux — verify `hostname -I` still works as primary method
- [ ] Verify fallback to `0.0.0.0` when no network interface found