### PR TITLE
docs: update sessions documentation to reflect current implementation

### DIFF
--- a/website/src/content/docs/usage/sessions.mdx
+++ b/website/src/content/docs/usage/sessions.mdx
@@ -3,59 +3,81 @@ title: Session Management
 description: Managing terminal sessions with tmux
 ---
 
-import { Aside, Steps } from '@astrojs/starlight/components';
+import { Aside, Steps } from "@astrojs/starlight/components";
 
-Termote uses tmux for persistent sessions that survive disconnects.
+Termote uses tmux windows for persistent sessions that survive disconnects.
 
-## Session Types
+## Default Session
 
-| Session | Purpose |
-|---------|---------|
-| Claude | Claude Code CLI |
-| Copilot | GitHub Copilot CLI |
-| Shell | Standard shell |
+Fresh installs start with a single **Shell** session. Create additional sessions as needed for different workflows (e.g., Claude Code, Copilot, builds).
 
-## Switching Sessions
+## Managing Sessions
 
-<Steps>
-1. Tap session icon in sidebar (desktop) or bottom nav (mobile)
-2. Session loads immediately
-3. Previous session continues in background
-</Steps>
+### Desktop
 
-## Session Persistence
+- **Switch**: Click session in left sidebar
+- **Edit**: Double-click session name, or hover and click pencil icon
+- **Remove**: Hover and click X icon (requires 2+ sessions)
+- **Add**: Click "+ Add session" at bottom
 
-Sessions persist until:
-- Explicitly closed
-- Server restart
-- tmux session killed
+### Mobile
+
+- **Switch**: Swipe right to open sidebar, tap session
+- **Edit**: Swipe left on session, tap Edit
+- **Remove**: Swipe left on session, tap Remove
+- **Add**: Tap "+ Add session" in sidebar
+
+## Session Features
+
+| Feature      | Description                            |
+| ------------ | -------------------------------------- |
+| Custom icons | Choose emoji icon for each session     |
+| Rename       | Change session name anytime            |
+| Auto-sync    | Sessions sync across browsers every 5s |
+| Persistence  | Sessions backed by tmux windows        |
 
 <Aside type="tip">
-Sessions survive network disconnects. Reconnect to pick up where you left off.
+  Sessions survive network disconnects. Reconnect to pick up where you left off.
 </Aside>
 
 ## tmux Commands
 
 ```bash
-# List sessions
-tmux ls
+# List windows (sessions)
+tmux list-windows
 
-# Attach to session
-tmux attach -t claude
+# Create new window
+tmux new-window -n myproject
 
-# Kill session
-tmux kill-session -t shell
+# Switch to window
+tmux select-window -t 0
+
+# Kill window
+tmux kill-window -t 0
 ```
+
+## API Endpoints
+
+Sessions are managed via tmux-api:
+
+| Endpoint                       | Method      | Description       |
+| ------------------------------ | ----------- | ----------------- |
+| `/api/tmux/windows`            | GET         | List all sessions |
+| `/api/tmux/new?name=X`         | POST        | Create session    |
+| `/api/tmux/select/{id}`        | POST        | Switch session    |
+| `/api/tmux/rename/{id}?name=X` | POST        | Rename session    |
+| `/api/tmux/kill/{id}`          | POST/DELETE | Remove session    |
 
 ## Troubleshooting
 
 ### Session not persisting
 
-1. Check tmux is running: `tmux ls`
+1. Check tmux is running: `tmux list-windows`
 2. Verify ttyd uses `-A` flag (attach-or-create)
-3. Check container logs: `docker logs termote`
+3. Check container logs: `docker logs termote` or `podman logs termote`
 
 ### WebSocket errors
 
-1. Check tmux-api logs: `docker logs termote`
+1. Check container logs: `docker logs termote` or `podman logs termote`
 2. Verify ttyd is running on port 7681
+3. Check API health: `curl http://localhost:7680/api/tmux/health`

--- a/website/src/content/docs/vi/usage/sessions.mdx
+++ b/website/src/content/docs/vi/usage/sessions.mdx
@@ -3,59 +3,81 @@ title: Quản lý phiên
 description: Quản lý phiên terminal với tmux
 ---
 
-import { Aside, Steps } from '@astrojs/starlight/components';
+import { Aside, Steps } from "@astrojs/starlight/components";
 
-Termote sử dụng tmux cho các phiên liên tục tồn tại qua ngắt kết nối.
+Termote sử dụng tmux windows cho các phiên liên tục tồn tại qua ngắt kết nối.
 
-## Loại phiên
+## Phiên mặc định
 
-| Phiên | Mục đích |
-|-------|----------|
-| Claude | Claude Code CLI |
-| Copilot | GitHub Copilot CLI |
-| Shell | Shell chuẩn |
+Cài đặt mới bắt đầu với một phiên **Shell** duy nhất. Tạo thêm phiên khi cần cho các workflow khác nhau (ví dụ: Claude Code, Copilot, builds).
 
-## Chuyển phiên
+## Quản lý phiên
 
-<Steps>
-1. Chạm icon phiên trong sidebar (desktop) hoặc nav dưới (di động)
-2. Phiên tải ngay lập tức
-3. Phiên trước tiếp tục chạy nền
-</Steps>
+### Desktop
 
-## Lưu trữ phiên
+- **Chuyển**: Click vào phiên trong sidebar bên trái
+- **Sửa**: Double-click tên phiên, hoặc hover và click icon bút chì
+- **Xóa**: Hover và click icon X (cần 2+ phiên)
+- **Thêm**: Click "+ Add session" ở dưới cùng
 
-Phiên tồn tại cho đến khi:
-- Đóng rõ ràng
-- Khởi động lại server
-- tmux session bị kill
+### Mobile
+
+- **Chuyển**: Vuốt phải để mở sidebar, chạm vào phiên
+- **Sửa**: Vuốt trái trên phiên, chạm Edit
+- **Xóa**: Vuốt trái trên phiên, chạm Remove
+- **Thêm**: Chạm "+ Add session" trong sidebar
+
+## Tính năng phiên
+
+| Tính năng       | Mô tả                                         |
+| --------------- | --------------------------------------------- |
+| Icon tùy chỉnh  | Chọn emoji icon cho mỗi phiên                 |
+| Đổi tên         | Đổi tên phiên bất cứ lúc nào                  |
+| Tự động đồng bộ | Phiên đồng bộ giữa các trình duyệt mỗi 5 giây |
+| Lưu trữ         | Phiên được lưu bởi tmux windows               |
 
 <Aside type="tip">
-Phiên tồn tại qua ngắt kết nối mạng. Kết nối lại để tiếp tục từ chỗ đã dừng.
+  Phiên tồn tại qua ngắt kết nối mạng. Kết nối lại để tiếp tục từ chỗ đã dừng.
 </Aside>
 
 ## Lệnh tmux
 
 ```bash
-# Liệt kê phiên
-tmux ls
+# Liệt kê windows (phiên)
+tmux list-windows
 
-# Attach vào phiên
-tmux attach -t claude
+# Tạo window mới
+tmux new-window -n myproject
 
-# Kill phiên
-tmux kill-session -t shell
+# Chuyển sang window
+tmux select-window -t 0
+
+# Kill window
+tmux kill-window -t 0
 ```
+
+## API Endpoints
+
+Phiên được quản lý qua tmux-api:
+
+| Endpoint                       | Method      | Mô tả                |
+| ------------------------------ | ----------- | -------------------- |
+| `/api/tmux/windows`            | GET         | Liệt kê tất cả phiên |
+| `/api/tmux/new?name=X`         | POST        | Tạo phiên            |
+| `/api/tmux/select/{id}`        | POST        | Chuyển phiên         |
+| `/api/tmux/rename/{id}?name=X` | POST        | Đổi tên phiên        |
+| `/api/tmux/kill/{id}`          | POST/DELETE | Xóa phiên            |
 
 ## Xử lý sự cố
 
 ### Phiên không lưu trữ
 
-1. Kiểm tra tmux đang chạy: `tmux ls`
+1. Kiểm tra tmux đang chạy: `tmux list-windows`
 2. Xác minh ttyd sử dụng cờ `-A` (attach-or-create)
-3. Kiểm tra log container: `docker logs termote`
+3. Kiểm tra log container: `docker logs termote` hoặc `podman logs termote`
 
 ### Lỗi WebSocket
 
-1. Kiểm tra log tmux-api: `docker logs termote`
+1. Kiểm tra log container: `docker logs termote` hoặc `podman logs termote`
 2. Xác minh ttyd đang chạy trên cổng 7681
+3. Kiểm tra API health: `curl http://localhost:7680/api/tmux/health`


### PR DESCRIPTION
## Summary
- Replace outdated preset session types (Claude, Copilot, Shell) with dynamic session management
- Add desktop/mobile UX documentation (sidebar, swipe gestures)
- Add session features table and tmux-api endpoints reference
- Fix troubleshooting commands (use `docker/podman logs` instead of non-existent `termote.sh logs`)

## Test plan
- [ ] Verify EN documentation renders correctly at `/usage/sessions/`
- [ ] Verify VI documentation renders correctly at `/vi/usage/sessions/`
- [ ] Check links and tables display properly