### PR TITLE
fix(installer): read from /dev/tty for piped script input

### DIFF
--- a/scripts/get.sh
+++ b/scripts/get.sh
@@ -70,7 +70,7 @@ confirm_install() {
         echo -e "Install Termote? [y/N] \c"
     fi
 
-    read -r response
+    read -r response </dev/tty
     case "$response" in
         [yY]|[yY][eE][sS]) return 0 ;;
         *) return 1 ;;
@@ -154,7 +154,7 @@ main() {
             stop_services
         else
             echo -e "Stop services before update? [Y/n] \c"
-            read -r response
+            read -r response </dev/tty
             case "$response" in
                 [nN]|[nN][oO])
                     error "Cannot update while services are running. Stop manually: ./scripts/termote.sh uninstall [native|container]"


### PR DESCRIPTION
## Summary
- Fix `curl | bash` installer not waiting for user input
- Read from `/dev/tty` instead of stdin (consumed by pipe)

## Test plan
- [ ] Run `curl -fsSL https://raw.githubusercontent.com/lamngockhuong/termote/fix/installer-read-tty/scripts/get.sh | bash`
- [ ] Verify prompts wait for user input