### PR TITLE
docs: add optional gum dependency to prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ flowchart TB
 make test                              # Run tests
 ```
 
+> **Tip**: Install [gum](https://github.com/charmbracelet/gum) for enhanced interactive menus (optional, bash fallback available)
+
 ## Installation
 
 ### One-liner (recommended)

--- a/website/src/content/docs/getting-started.mdx
+++ b/website/src/content/docs/getting-started.mdx
@@ -9,6 +9,7 @@ import { Aside, Steps } from "@astrojs/starlight/components";
 
 - Docker or Podman (for Container mode)
 - or ttyd + tmux + Go (for Native mode)
+- Optional: [gum](https://github.com/charmbracelet/gum) for enhanced interactive menus
 
 ## One-Liner Install
 

--- a/website/src/content/docs/vi/getting-started.mdx
+++ b/website/src/content/docs/vi/getting-started.mdx
@@ -9,6 +9,7 @@ import { Aside, Steps } from "@astrojs/starlight/components";
 
 - Docker hoặc Podman (cho chế độ Container)
 - hoặc ttyd + tmux + Go (cho chế độ Native)
+- Tùy chọn: [gum](https://github.com/charmbracelet/gum) để có menu tương tác đẹp hơn
 
 ## Cài đặt một dòng
 


### PR DESCRIPTION
## Summary
- Add note about optional [gum](https://github.com/charmbracelet/gum) installation for enhanced interactive menus
- termote.sh has bash fallback, so gum is not required
- Updated README.md, EN and VI getting-started docs

## Test plan
- [x] Verify links work correctly
- [x] Check documentation renders properly