### PR TITLE
fix(gestures): enable swipe scroll in IME input mode

### DIFF
--- a/pwa/src/App.tsx
+++ b/pwa/src/App.tsx
@@ -34,6 +34,7 @@ export default function App() {
   const [helpOpen, setHelpOpen] = useState(false)
   const [showTitleTooltip, setShowTitleTooltip] = useState(false)
   const [ctrlActive, setCtrlActive] = useState(false)
+  const [imeMode, setImeMode] = useState(false)
   const isMobile = useIsMobile()
   const { isVisible: keyboardVisible, keyboardHeight } = useKeyboardVisible()
   const {
@@ -53,8 +54,8 @@ export default function App() {
         sendKeyToTerminal(terminalRef.current, 'c', { ctrl: true }),
       onSwipeRight: () => sendKeyToTerminal(terminalRef.current, 'Tab'),
       onSwipeUp: () => {
-        if (keyboardVisible && terminalContainerRef.current) {
-          // Keyboard open - scroll container to see hidden content
+        if ((keyboardVisible || imeMode) && terminalContainerRef.current) {
+          // Keyboard or IME mode - scroll container to see hidden content
           terminalContainerRef.current.scrollTop += 150
         } else if (isInCopyMode()) {
           // In copy mode - send PageDown
@@ -62,8 +63,8 @@ export default function App() {
         }
       },
       onSwipeDown: () => {
-        if (keyboardVisible && terminalContainerRef.current) {
-          // Keyboard open - scroll container to see hidden content
+        if ((keyboardVisible || imeMode) && terminalContainerRef.current) {
+          // Keyboard or IME mode - scroll container to see hidden content
           terminalContainerRef.current.scrollTop -= 150
         } else if (isInCopyMode()) {
           // In copy mode - send PageUp
@@ -74,7 +75,7 @@ export default function App() {
       onPinchIn: decrease,
       onPinchOut: increase,
     }),
-    [decrease, increase, keyboardVisible],
+    [decrease, increase, keyboardVisible, imeMode],
   )
 
   const toggleKeyboard = () => {
@@ -300,6 +301,8 @@ export default function App() {
         onSendText={handleSendText}
         ctrlActive={ctrlActive}
         onCtrlChange={setCtrlActive}
+        imeMode={imeMode}
+        onImeModeChange={setImeMode}
       />
 
       {/* Mobile bottom navigation */}

--- a/pwa/src/components/keyboard-toolbar.tsx
+++ b/pwa/src/components/keyboard-toolbar.tsx
@@ -40,6 +40,8 @@ interface Props {
   onCtrlChange?: (active: boolean) => void
   shiftActive?: boolean
   onShiftChange?: (active: boolean) => void
+  imeMode?: boolean
+  onImeModeChange?: (active: boolean) => void
 }
 
 interface KeyConfig {
@@ -169,11 +171,14 @@ export function KeyboardToolbar({
   onCtrlChange,
   shiftActive: externalShiftActive,
   onShiftChange,
+  imeMode: externalImeMode,
+  onImeModeChange,
 }: Props) {
   const [internalCtrlActive, setInternalCtrlActive] = useState(false)
   const [internalShiftActive, setInternalShiftActive] = useState(false)
   const [expanded, setExpanded] = useState(false)
-  const [imeMode, setImeMode] = useState(false)
+  const [internalImeMode, setInternalImeMode] = useState(false)
+  const imeMode = externalImeMode ?? internalImeMode
   const [imeText, setImeText] = useState('')
   const imeInputRef = useRef<HTMLInputElement>(null)
   const imeFocusTimeoutRef = useRef<number | null>(null)
@@ -213,20 +218,26 @@ export function KeyboardToolbar({
     onShiftChange?.(newValue)
   }
 
+  const setImeMode = useCallback(
+    (value: boolean) => {
+      setInternalImeMode(value)
+      onImeModeChange?.(value)
+    },
+    [onImeModeChange],
+  )
+
   const toggleImeMode = useCallback(() => {
     haptic('medium')
-    setImeMode((prev) => {
-      const next = !prev
-      if (next) {
-        imeFocusTimeoutRef.current = window.setTimeout(
-          () => imeInputRef.current?.focus(),
-          50,
-        )
-      }
-      return next
-    })
+    const next = !imeMode
+    setImeMode(next)
+    if (next) {
+      imeFocusTimeoutRef.current = window.setTimeout(
+        () => imeInputRef.current?.focus(),
+        50,
+      )
+    }
     setImeText('')
-  }, [haptic])
+  }, [haptic, imeMode, setImeMode])
 
   const handleImeSend = useCallback(() => {
     if (imeText.trim() && onSendText) {


### PR DESCRIPTION
## Summary
- Lift `imeMode` state from KeyboardToolbar to App level
- Enable swipe up/down scroll when IME input mode (Vietnamese/CJK) is active
- Matches existing behavior when native keyboard is visible

## Test plan
- [ ] Open PWA on mobile
- [ ] Tap Languages button to enter IME mode
- [ ] Swipe up/down on terminal area → should scroll container
- [ ] Verify normal keyboard mode still scrolls correctly