### PR TITLE
docs: add macOS sleep prevention guide

### DIFF
--- a/website/src/content/docs/installation/docker.mdx
+++ b/website/src/content/docs/installation/docker.mdx
@@ -66,6 +66,26 @@ docker run -d --name termote -p 7680:7680 \
   or `git`).
 </Aside>
 
+## Prevent macOS Sleep
+
+macOS automatically sleeps after inactivity, disconnecting remote terminal sessions — even with containers running. Use `caffeinate` to keep the machine awake:
+
+```bash
+# Prevent system sleep (runs until you press Ctrl+C)
+caffeinate -s
+
+# Or run in background
+caffeinate -s &
+
+# Stop background caffeinate
+pkill caffeinate
+```
+
+<Aside type="tip">
+  Use `caffeinate -s` (system sleep only) instead of `-d` (display sleep) — you
+  don't need the display on for remote access.
+</Aside>
+
 ## Troubleshooting
 
 ### Quick Diagnostics

--- a/website/src/content/docs/installation/native.mdx
+++ b/website/src/content/docs/installation/native.mdx
@@ -61,6 +61,26 @@ ps aux | grep tmux-api
 ./scripts/termote.sh install native
 ```
 
+## Prevent macOS Sleep
+
+macOS automatically sleeps after inactivity, disconnecting remote terminal sessions. Use `caffeinate` to keep the machine awake while Termote is running:
+
+```bash
+# Prevent system sleep (runs until you press Ctrl+C)
+caffeinate -s
+
+# Or run in background
+caffeinate -s &
+
+# Stop background caffeinate
+pkill caffeinate
+```
+
+<Aside type="tip">
+  Use `caffeinate -s` (system sleep only) instead of `-d` (display sleep) — you
+  don't need the display on for remote access.
+</Aside>
+
 ## Troubleshooting
 
 ### Quick Diagnostics

--- a/website/src/content/docs/vi/installation/docker.mdx
+++ b/website/src/content/docs/vi/installation/docker.mdx
@@ -66,6 +66,26 @@ docker run -d --name termote -p 7680:7680 \
   hoặc `git`).
 </Aside>
 
+## Ngăn macOS Sleep
+
+macOS tự động sleep sau một khoảng thời gian không hoạt động, làm mất kết nối terminal từ xa — ngay cả khi container đang chạy. Dùng `caffeinate` để giữ máy luôn thức:
+
+```bash
+# Ngăn system sleep (chạy cho đến khi bạn nhấn Ctrl+C)
+caffeinate -s
+
+# Hoặc chạy nền
+caffeinate -s &
+
+# Dừng caffeinate nền
+pkill caffeinate
+```
+
+<Aside type="tip">
+  Dùng `caffeinate -s` (chỉ ngăn system sleep) thay vì `-d` (ngăn tắt màn hình)
+  — bạn không cần màn hình sáng cho truy cập từ xa.
+</Aside>
+
 ## Khắc phục sự cố
 
 ### Chẩn đoán nhanh

--- a/website/src/content/docs/vi/installation/native.mdx
+++ b/website/src/content/docs/vi/installation/native.mdx
@@ -61,6 +61,26 @@ ps aux | grep tmux-api
 ./scripts/termote.sh install native
 ```
 
+## Ngăn macOS Sleep
+
+macOS tự động sleep sau một khoảng thời gian không hoạt động, làm mất kết nối terminal từ xa. Dùng `caffeinate` để giữ máy luôn thức khi Termote đang chạy:
+
+```bash
+# Ngăn system sleep (chạy cho đến khi bạn nhấn Ctrl+C)
+caffeinate -s
+
+# Hoặc chạy nền
+caffeinate -s &
+
+# Dừng caffeinate nền
+pkill caffeinate
+```
+
+<Aside type="tip">
+  Dùng `caffeinate -s` (chỉ ngăn system sleep) thay vì `-d` (ngăn tắt màn hình)
+  — bạn không cần màn hình sáng cho truy cập từ xa.
+</Aside>
+
 ## Khắc phục sự cố
 
 ### Chẩn đoán nhanh


### PR DESCRIPTION
## Summary
- Added `caffeinate` usage guide to prevent macOS sleep during remote terminal sessions
- Updated both native and container installation docs (EN + VI)
- Explains `caffeinate -s` for system sleep prevention without keeping display on

## Test plan
- [ ] Verify docs render correctly on Starlight site
- [ ] Confirm `caffeinate -s` tip is visible in both EN and VI versions