### PR TITLE
fix(cli): stop services before binary copy on reinstall

### DIFF
--- a/scripts/termote.sh
+++ b/scripts/termote.sh
@@ -476,15 +476,12 @@ cmd_install() {
         info "Release mode (using pre-built artifacts)"
     fi
 
-    # Stop the other mode to avoid port conflicts
-    if [[ "$mode" == "container" || "$mode" == "docker" ]]; then
-        stop_native_services
-    else
-        local crt=""
-        command -v podman &>/dev/null && crt="podman"
-        command -v docker &>/dev/null && crt="${crt:-docker}"
-        [[ -n "$crt" ]] && $crt compose --profile docker down 2>/dev/null || true
-    fi
+    # Stop running services to avoid port conflicts and "Text file busy" on binary overwrite
+    stop_native_services
+    local crt=""
+    command -v podman &>/dev/null && crt="podman"
+    command -v docker &>/dev/null && crt="${crt:-docker}"
+    [[ -n "$crt" ]] && $crt compose --profile docker down 2>/dev/null || true
 
     echo ""
     echo -e "${BOLD}=== Termote Install ($mode) ===${NC}"


### PR DESCRIPTION
## Summary
- Fix "Text file busy" error on Linux when reinstalling native mode
- Stop all services (native + container) early before binary copy at step 2/4
- Previously native services were only stopped at step 4/4, after the copy failed

## Test plan
- [ ] Reinstall native mode on Linux (Ubuntu) — no ETXTBSY error
- [ ] Reinstall native mode on macOS — no regression