### PR TITLE
fix(cli): pre-cache sudo credentials for uninterrupted tailscale operations

### DIFF
--- a/scripts/get.sh
+++ b/scripts/get.sh
@@ -220,6 +220,8 @@ main() {
 
     # Stop services if running (to avoid "Text file busy" error)
     if services_running; then
+        # Pre-cache sudo for tailscale commands so the flow runs uninterrupted
+        command -v tailscale >/dev/null 2>&1 && sudo -v 2>/dev/null || true
         warn "Services are running"
         if [ "$AUTO_YES" = true ]; then
             stop_services

--- a/scripts/termote.sh
+++ b/scripts/termote.sh
@@ -333,6 +333,11 @@ start_native_mode() {
     start_ttyd
 }
 
+# Pre-cache sudo credentials once so tailscale commands don't prompt mid-flow
+precache_sudo_for_tailscale() {
+    command -v tailscale &>/dev/null && sudo -v 2>/dev/null || true
+}
+
 # Setup Tailscale serve (only reset if saved config had Tailscale previously)
 setup_tailscale() {
     if [[ -n "$TAILSCALE" ]]; then
@@ -541,6 +546,10 @@ cmd_install() {
         *) error "Unknown mode: $mode" ;;
     esac
 
+    # Only pre-cache sudo if tailscale commands will actually run
+    if [[ -n "$TAILSCALE" ]] || { [[ -f "$CONFIG_FILE" ]] && grep -q '^TERMOTE_TAILSCALE=.' "$CONFIG_FILE" 2>/dev/null; }; then
+        precache_sudo_for_tailscale
+    fi
     setup_tailscale
 
     # Save config for future restarts/updates
@@ -583,6 +592,7 @@ cmd_uninstall() {
 
     # Tailscale reset
     if command -v tailscale &>/dev/null; then
+        precache_sudo_for_tailscale
         info "Resetting Tailscale serve..."
         sudo tailscale serve reset 2>/dev/null || true
     fi

--- a/tests/test-get.sh
+++ b/tests/test-get.sh
@@ -254,6 +254,13 @@ test_update_mode() {
     else
         pass "stop_services preserves config (no uninstall all)"
     fi
+
+    # Verify sudo credentials pre-cache before stop_services
+    if grep -B15 'stop_services' "$PROJECT_DIR/scripts/get.sh" | grep -q 'sudo -v'; then
+        pass "sudo credentials pre-cached before stop_services"
+    else
+        fail "sudo pre-cache" "sudo -v before stop_services" "not found"
+    fi
 }
 
 test_version_pinning() {

--- a/tests/test-termote.sh
+++ b/tests/test-termote.sh
@@ -123,6 +123,23 @@ test_arg_parsing() {
     else
         fail "--tailscale" "TAILSCALE=" "not found"
     fi
+
+    # Verify sudo pre-cache helper exists and is used
+    if grep -q 'precache_sudo_for_tailscale' "$SCRIPT"; then
+        pass "precache_sudo_for_tailscale helper defined"
+    else
+        fail "sudo helper" "precache_sudo_for_tailscale" "not found"
+    fi
+    if grep -B5 'setup_tailscale' "$SCRIPT" | grep -q 'precache_sudo_for_tailscale'; then
+        pass "sudo pre-cache before setup_tailscale"
+    else
+        fail "sudo pre-cache install" "precache_sudo_for_tailscale before setup_tailscale" "not found"
+    fi
+    if grep -B3 'sudo tailscale serve reset' "$SCRIPT" | grep -q 'precache_sudo_for_tailscale'; then
+        pass "sudo pre-cache before tailscale reset in uninstall"
+    else
+        fail "sudo pre-cache uninstall" "precache_sudo_for_tailscale before serve reset" "not found"
+    fi
 }
 
 # =============================================================================


### PR DESCRIPTION
## Summary
- Pre-cache sudo credentials before tailscale operations so tmux sessions don't get interrupted by password prompts mid-flow

## Changes
- **scripts/termote.sh**: Add `precache_sudo_for_tailscale()` helper, use it in install (when tailscale configured) and uninstall (before `tailscale serve reset`)
- **scripts/get.sh**: Pre-cache sudo inside `services_running` block before stopping services
- **tests/**: Add tests verifying sudo pre-cache placement

## Test plan
- [x] `make test-cli` — 52 passed, 0 failed
- [x] `make test-get` — 38 passed, 0 failed
- [ ] Manual: run `./scripts/get.sh --update` in tmux on a machine with tailscale — should prompt password once at start, not mid-flow