### PR TITLE
feat(pwa): add Clear Cache & Reload button to settings menu

### DIFF
--- a/docs/codebase-summary.md
+++ b/docs/codebase-summary.md
@@ -72,7 +72,7 @@ Main orchestrator combining:
 - Session sidebar with collapse toggle (desktop) / slide-over panel (mobile)
 - Terminal frame with ttyd iframe
 - Keyboard toolbar with special keys
-- Settings menu with theme toggle
+- Settings menu with theme toggle and cache clearing
 - Font size controls (A-/A+)
 - Fullscreen toggle (desktop only, Fullscreen API)
 - Gesture handlers → terminal commands (mobile only)

--- a/docs/self-test-checklist.md
+++ b/docs/self-test-checklist.md
@@ -62,6 +62,7 @@ Manual testing checklist for Termote features before release.
 - [ ] Desktop: Icon list displays correctly (no layout issues)
 - [ ] About page looks good in dark mode
 - [ ] Settings button clickable on mobile
+- [ ] Clear Cache & Reload button works (unregisters SW, clears caches, reloads)
 
 ### Install/Offline
 

--- a/docs/self-test-checklist.vi.md
+++ b/docs/self-test-checklist.vi.md
@@ -62,6 +62,7 @@ Kiểm tra thủ công các tính năng Termote trước khi release.
 - [ ] Desktop: Danh sách icon hiển thị đúng (không lỗi layout)
 - [ ] Trang About đẹp trong dark mode
 - [ ] Nút Settings nhấn được trên mobile
+- [ ] Nút Clear Cache & Reload hoạt động (hủy SW, xóa cache, reload trang)
 
 ### Cài Đặt/Offline
 

--- a/docs/system-architecture.md
+++ b/docs/system-architecture.md
@@ -53,7 +53,7 @@ React SPA with:
 - **Hammer.js**: Touch gesture recognition (mobile only)
 - **Session Sidebar**: Switch between tmux windows, add/edit/remove (collapsible on desktop)
 - **Keyboard Toolbar**: Virtual keys, Ctrl combos, scroll controls
-- **Settings Menu**: Theme toggle (light/dark/system)
+- **Settings Menu**: Theme toggle (light/dark/system), Clear Cache & Reload
 - **Font Controls**: Adjustable font size (6-24px)
 - **Fullscreen Toggle**: Desktop-only fullscreen mode via Fullscreen API
 - **Responsive Layout**: Collapsible desktop sidebar, mobile slide-over panel

--- a/pwa/src/components/settings-menu.tsx
+++ b/pwa/src/components/settings-menu.tsx
@@ -7,9 +7,30 @@ interface Props {
   onOpenHelp: () => void
 }
 
+async function clearCacheAndReload() {
+  try {
+    if ('serviceWorker' in navigator) {
+      const registrations = await navigator.serviceWorker.getRegistrations()
+      await Promise.all(registrations.map((r) => r.unregister()))
+    }
+    if ('caches' in window) {
+      const cacheNames = await caches.keys()
+      await Promise.all(cacheNames.map((name) => caches.delete(name)))
+    }
+  } finally {
+    window.location.reload()
+  }
+}
+
 export function SettingsMenu({ onOpenAbout, onOpenHelp }: Props) {
   const [isOpen, setIsOpen] = useState(false)
+  const [clearing, setClearing] = useState(false)
   const menuRef = useRef<HTMLDivElement>(null)
+
+  const handleClearCache = async () => {
+    setClearing(true)
+    await clearCacheAndReload()
+  }
 
   // Close on click outside
   useEffect(() => {
@@ -66,6 +87,16 @@ export function SettingsMenu({ onOpenAbout, onOpenHelp }: Props) {
             className="w-full px-3 py-2 text-left rounded-lg hover:bg-zinc-200/50 dark:hover:bg-zinc-700/50 transition-colors"
           >
             About Termote
+          </button>
+
+          <hr className="my-2 border-zinc-300/30 dark:border-zinc-700/30" />
+
+          <button
+            onClick={handleClearCache}
+            disabled={clearing}
+            className="w-full px-3 py-2 text-left rounded-lg hover:bg-zinc-200/50 dark:hover:bg-zinc-700/50 transition-colors text-red-600 dark:text-red-400 disabled:opacity-50"
+          >
+            {clearing ? 'Clearing...' : 'Clear Cache & Reload'}
           </button>
         </div>
       )}

--- a/website/src/content/docs/installation/docker.mdx
+++ b/website/src/content/docs/installation/docker.mdx
@@ -130,12 +130,13 @@ curl localhost:7680/api/tmux/health
 
 ### Common Issues
 
-| Issue            | Solution                                   |
-| ---------------- | ------------------------------------------ |
-| Port in use      | `lsof -i :7680` then kill or use `--port`  |
-| Container crash  | `docker logs termote` to see error         |
-| Auth not working | Restart container, check logs for password |
-| WebSocket error  | Check ttyd running inside container        |
+| Issue            | Solution                                     |
+| ---------------- | -------------------------------------------- |
+| Port in use      | `lsof -i :7680` then kill or use `--port`    |
+| Container crash  | `docker logs termote` to see error           |
+| Auth not working | Restart container, check logs for password   |
+| WebSocket error  | Check ttyd running inside container          |
+| Stale PWA cache  | Settings → "Clear Cache & Reload" to refresh |
 
 ### Restart / Reset
 

--- a/website/src/content/docs/installation/native.mdx
+++ b/website/src/content/docs/installation/native.mdx
@@ -118,12 +118,13 @@ TERMOTE_PWA_DIR=../pwa/dist ./tmux-api-native
 
 ### Common Issues
 
-| Issue          | Solution                                          |
-| -------------- | ------------------------------------------------- |
-| Port in use    | `lsof -i :7680` then kill process                 |
-| ttyd missing   | `brew install ttyd` (macOS) or `apt install ttyd` |
-| Binary missing | `cd tmux-api && go build -o tmux-api-native .`    |
-| PWA not built  | `cd pwa && pnpm build`                            |
+| Issue           | Solution                                          |
+| --------------- | ------------------------------------------------- |
+| Port in use     | `lsof -i :7680` then kill process                 |
+| ttyd missing    | `brew install ttyd` (macOS) or `apt install ttyd` |
+| Binary missing  | `cd tmux-api && go build -o tmux-api-native .`    |
+| PWA not built   | `cd pwa && pnpm build`                            |
+| Stale PWA cache | Settings → "Clear Cache & Reload" to refresh      |
 
 ### tmux Session
 

--- a/website/src/content/docs/vi/installation/docker.mdx
+++ b/website/src/content/docs/vi/installation/docker.mdx
@@ -136,6 +136,7 @@ curl localhost:7680/api/tmux/health
 | Container crash      | `docker logs termote` để xem lỗi                 |
 | Auth không hoạt động | Restart container, kiểm tra logs để lấy password |
 | Lỗi WebSocket        | Kiểm tra ttyd đang chạy trong container          |
+| PWA cache cũ         | Settings → "Clear Cache & Reload" để làm mới     |
 
 ### Khởi động lại / Reset
 

--- a/website/src/content/docs/vi/installation/native.mdx
+++ b/website/src/content/docs/vi/installation/native.mdx
@@ -124,6 +124,7 @@ TERMOTE_PWA_DIR=../pwa/dist ./tmux-api-native
 | Thiếu ttyd     | `brew install ttyd` (macOS) hoặc `apt install ttyd` |
 | Thiếu binary   | `cd tmux-api && go build -o tmux-api-native .`      |
 | PWA chưa build | `cd pwa && pnpm build`                              |
+| PWA cache cũ   | Settings → "Clear Cache & Reload" để làm mới        |
 
 ### tmux Session
 


### PR DESCRIPTION
## Summary
- Add "Clear Cache & Reload" button in Settings menu to help users clear stale PWA cache
- Unregisters service workers, clears Cache Storage, and hard reloads
- Uses try/finally to ensure reload happens even if clearing fails

## Changes
- `pwa/src/components/settings-menu.tsx`: Add clearCacheAndReload function and button
- `docs/*`: Update documentation to reflect new feature
- `website/*`: Add PWA cache troubleshooting tip

## Test plan
- [ ] Open Settings menu on mobile/desktop
- [ ] Click "Clear Cache & Reload" button
- [ ] Verify page reloads with fresh content
- [ ] Check DevTools → Application → Service Workers (should be unregistered)
- [ ] Check DevTools → Application → Cache Storage (should be empty)