### PR TITLE
refactor(pwa): move expand/collapse toggle after arrow keys

### DIFF
--- a/pwa/src/components/keyboard-toolbar.tsx
+++ b/pwa/src/components/keyboard-toolbar.tsx
@@ -425,11 +425,15 @@ export function KeyboardToolbar({
               : undefined
           }
         >
-          {keyConfig.isExpandToggle
-            ? expanded
-              ? <Minimize2 size={ICON_SIZE} />
-              : <Expand size={ICON_SIZE} />
-            : keyConfig.label}
+          {keyConfig.isExpandToggle ? (
+            expanded ? (
+              <Minimize2 size={ICON_SIZE} />
+            ) : (
+              <Expand size={ICON_SIZE} />
+            )
+          ) : (
+            keyConfig.label
+          )}
         </button>
       ))}
 


### PR DESCRIPTION
## Summary
- Moved expand/collapse toggle button from first position to after arrow/extra keys (before utility keys) for better UX flow
- Promoted toggle key config to module-level constant (`EXPAND_TOGGLE_KEY`) consistent with other key arrays

## Test plan
- [ ] Verify expand/collapse button appears after ArrowRight in minimal mode
- [ ] Verify expand/collapse button appears after PageDown/Insert in expanded mode
- [ ] Verify toggle switches between Expand/Minimize2 icons correctly
- [ ] Verify all other toolbar buttons remain functional