### PR TITLE
fix(pwa): retry button unresponsive on mobile

### DIFF
--- a/pwa/src/components/terminal-frame.tsx
+++ b/pwa/src/components/terminal-frame.tsx
@@ -79,15 +79,19 @@ export const TerminalFrame = forwardRef<TerminalFrameHandle, Props>(
     const iframeRef = useRef<HTMLIFrameElement>(null)
     const [terminalSrc, setTerminalSrc] = useState<string | null>(null)
     const [tokenError, setTokenError] = useState<string | null>(null)
+    const [loading, setLoading] = useState(false)
 
     // Fetch a new token each time the iframe needs to load (theme change triggers key change)
     const loadTerminal = useCallback(async () => {
       try {
         setTokenError(null)
+        setLoading(true)
         const token = await fetchTerminalToken()
         setTerminalSrc(`/terminal/?token=${token}`)
       } catch {
         setTokenError('Failed to load terminal')
+      } finally {
+        setLoading(false)
       }
     }, [])
 
@@ -150,7 +154,7 @@ export const TerminalFrame = forwardRef<TerminalFrameHandle, Props>(
     // key={terminalSrc} forces iframe reload when token or theme changes
     if (tokenError) {
       return (
-        <div className="flex-1 flex flex-col items-center justify-center text-red-400">
+        <div className="flex-1 flex flex-col items-center justify-center text-red-400 relative z-10">
           <p>{tokenError}</p>
           <button
             onClick={loadTerminal}
@@ -161,7 +165,13 @@ export const TerminalFrame = forwardRef<TerminalFrameHandle, Props>(
         </div>
       )
     }
-    if (!terminalSrc) return null
+    if (loading || !terminalSrc) {
+      return (
+        <div className="flex-1 flex items-center justify-center text-zinc-400 relative z-10">
+          Connecting...
+        </div>
+      )
+    }
     return (
       <iframe
         key={terminalSrc}

--- a/pwa/src/hooks/use-tmux-api.ts
+++ b/pwa/src/hooks/use-tmux-api.ts
@@ -56,8 +56,34 @@ export async function sendKeys(target: string, keys: string): Promise<boolean> {
 }
 
 export async function fetchTerminalToken(): Promise<string> {
-  const res = await fetch(`${API_BASE}/terminal-token`)
-  if (!res.ok) throw new Error(`Token request failed: ${res.status}`)
-  const data = await res.json()
-  return data.token
+  const attempts = 3
+  const delay = (ms: number) => new Promise((r) => setTimeout(r, ms))
+
+  for (let i = 0; i < attempts; i++) {
+    const ctrl = new AbortController()
+    const timeout = setTimeout(() => ctrl.abort(), 5000)
+    try {
+      const res = await fetch(`${API_BASE}/terminal-token`, {
+        signal: ctrl.signal,
+      })
+      clearTimeout(timeout)
+      const isRetryable =
+        [502, 503, 504].includes(res.status) && i < attempts - 1
+      if (isRetryable) {
+        await delay(1000 * (i + 1))
+        continue
+      }
+      if (!res.ok) throw new Error(`Token request failed: ${res.status}`)
+      const data = await res.json()
+      return data.token
+    } catch (err) {
+      clearTimeout(timeout)
+      if (i < attempts - 1) {
+        await delay(1000 * (i + 1))
+        continue
+      }
+      throw err
+    }
+  }
+  throw new Error('Token request failed after retries')
 }


### PR DESCRIPTION
## Summary
- Gesture overlay (`absolute inset-0 touch-none`) blocked tap events on Retry button when terminal failed to load
- Added `relative z-10` to error/loading UI so it renders above gesture layer
- Added loading state with "Connecting..." feedback during token fetch
- Added auto-retry (3 attempts, linear backoff) for transient 502/503/504 proxy errors
- Added 5s timeout per fetch to prevent silent hangs on mobile

## Test plan
- [ ] Mobile: disconnect server → see error → reconnect server → tap Retry → terminal loads
- [ ] Mobile: swipe gestures still work when terminal is active
- [ ] Desktop: Retry button still works as before
- [ ] Verify "Connecting..." shows during initial load and reconnect