### PR TITLE
feat(cli): add link/unlink commands for global termote command

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,7 @@ termote/
 │   ├── serve.go            # Server (static files, proxy, auth)
 │   └── tmux.go             # tmux API handlers
 ├── scripts/                # Shell scripts
-│   ├── termote.sh          # Unified CLI (install/uninstall/health)
+│   ├── termote.sh          # Unified CLI (install/uninstall/health/link)
 │   └── get.sh              # Online installer (curl-able)
 ├── tests/                  # Test suite
 │   ├── test-termote.sh     # CLI tests
@@ -64,6 +64,8 @@ termote/
 ./scripts/termote.sh install container --no-auth       # Without auth
 ./scripts/termote.sh install container --tailscale host  # Tailscale HTTPS
 ./scripts/termote.sh install container --fresh         # Force new password (ignore saved)
+./scripts/termote.sh link                              # Create 'termote' global command
+./scripts/termote.sh unlink                            # Remove global command
 curl -fsSL https://... | bash -s -- --update           # Auto-update with saved config
 ```
 

--- a/README.md
+++ b/README.md
@@ -83,8 +83,11 @@ flowchart TB
 ./scripts/termote.sh                   # Interactive menu
 ./scripts/termote.sh install container # Container mode (docker/podman)
 ./scripts/termote.sh install native    # Native mode (host tools)
+./scripts/termote.sh link              # Create 'termote' global command
 make test                              # Run tests
 ```
+
+> After `link`, use `termote` from anywhere: `termote health`, `termote install native --lan`
 
 > **Tip**: Install [gum](https://github.com/charmbracelet/gum) for enhanced interactive menus (optional, bash fallback available)
 

--- a/README.vi.md
+++ b/README.vi.md
@@ -83,8 +83,11 @@ flowchart TB
 ./scripts/termote.sh                   # Menu tương tác
 ./scripts/termote.sh install container # Chế độ container (docker/podman)
 ./scripts/termote.sh install native    # Chế độ native (công cụ host)
+./scripts/termote.sh link              # Tạo lệnh 'termote' toàn cục
 make test                              # Chạy tests
 ```
+
+> Sau khi `link`, dùng `termote` từ bất kỳ đâu: `termote health`, `termote install native --lan`
 
 > **Mẹo**: Cài [gum](https://github.com/charmbracelet/gum) để có menu tương tác đẹp hơn (tùy chọn, có fallback bash)
 

--- a/docs/codebase-summary.md
+++ b/docs/codebase-summary.md
@@ -52,7 +52,7 @@ termote/
 │   ├── integration_test.go     # Integration tests (requires tmux)
 │   └── go.mod
 ├── scripts/
-│   ├── termote.sh              # Unified CLI (install/uninstall/health)
+│   ├── termote.sh              # Unified CLI (install/uninstall/health/link)
 │   └── get.sh                  # Online curl|bash installer
 ├── tests/                      # Shell script tests
 │   ├── test-termote.sh         # CLI tests

--- a/docs/deployment-guide.md
+++ b/docs/deployment-guide.md
@@ -20,6 +20,7 @@ Single container with tmux-api + ttyd + tmux.
 ./scripts/termote.sh install container          # localhost with basic auth
 ./scripts/termote.sh install container --no-auth  # localhost without auth
 ./scripts/termote.sh install container --lan    # LAN accessible
+./scripts/termote.sh link                       # Create 'termote' global command
 ```
 
 **Container Runtime:** Auto-detects podman (preferred) or docker.

--- a/docs/self-test-checklist.md
+++ b/docs/self-test-checklist.md
@@ -46,6 +46,12 @@ Manual testing checklist for Termote features before release.
 - [ ] `./scripts/termote.sh uninstall native` stops processes
 - [ ] `./scripts/termote.sh uninstall all` cleans everything
 
+### Link/Unlink
+
+- [ ] `./scripts/termote.sh link` creates symlink (tries /usr/local/bin, falls back to ~/.local/bin)
+- [ ] `termote help` works after linking
+- [ ] `./scripts/termote.sh unlink` removes symlink and shows restore hint
+
 ---
 
 ## PWA Features

--- a/docs/self-test-checklist.vi.md
+++ b/docs/self-test-checklist.vi.md
@@ -46,6 +46,12 @@ Kiểm tra thủ công các tính năng Termote trước khi release.
 - [ ] `./scripts/termote.sh uninstall native` dừng các process
 - [ ] `./scripts/termote.sh uninstall all` dọn sạch tất cả
 
+### Link/Unlink
+
+- [ ] `./scripts/termote.sh link` tạo symlink (thử /usr/local/bin, fallback ~/.local/bin)
+- [ ] `termote help` hoạt động sau khi link
+- [ ] `./scripts/termote.sh unlink` xóa symlink và hiện hướng dẫn khôi phục
+
 ---
 
 ## Tính Năng PWA

--- a/scripts/get.sh
+++ b/scripts/get.sh
@@ -308,6 +308,11 @@ main() {
     [[ -z "$mode" ]] && mode="native"
 
     ./scripts/termote.sh install "$mode" "${args[@]}"
+
+    # Create 'termote' command symlink (skip if old version without link command)
+    if grep -q 'cmd_link()' ./scripts/termote.sh 2>/dev/null; then
+        ./scripts/termote.sh link
+    fi
 }
 
 main "$@"

--- a/scripts/termote.sh
+++ b/scripts/termote.sh
@@ -781,6 +781,8 @@ cmd_help() {
     echo "  uninstall <mode>  Remove installation"
     echo "  health            Check service health"
     echo "  logs [service]    View logs (ttyd, tmux-api, all, follow, clean)"
+    echo "  link              Create 'termote' symlink in /usr/local/bin"
+    echo "  unlink            Remove 'termote' symlink"
     echo "  help              Show this help"
     echo ""
     echo "Modes:"
@@ -801,6 +803,95 @@ cmd_help() {
     echo "  termote.sh install native --lan      # Native + LAN"
     echo "  termote.sh install native --no-auth  # Without auth"
     echo "  termote.sh uninstall all             # Full cleanup"
+    echo "  termote.sh link                      # Create 'termote' command"
+}
+
+# =============================================================================
+# LINK/UNLINK COMMANDS
+# =============================================================================
+
+cmd_link() {
+    local target="/usr/local/bin/termote"
+    local source="$SCRIPT_DIR/termote.sh"
+    local display_source="${source/#$HOME/\$HOME}"
+
+    # Detect context: git repo (dev) or installed (~/.termote)
+    local context="installed"
+    if git -C "$SCRIPT_DIR" rev-parse --git-dir &>/dev/null; then
+        context="development"
+    fi
+
+    # Check if already linked to this source
+    if [[ -L "$target" ]]; then
+        local current_target
+        current_target=$(readlink "$target")
+        if [[ "$current_target" == "$source" ]]; then
+            info "Already linked: $target -> $display_source"
+            return 0
+        else
+            # Linked to different location
+            local display_current="${current_target/#$HOME/\$HOME}"
+            warn "Currently linked to: $display_current"
+            info "Updating to: $display_source"
+        fi
+    fi
+
+    # Try to create symlink: /usr/local/bin first, then ~/.local/bin
+    if ln -sf "$source" "$target" 2>/dev/null; then
+        info "Created symlink: $target -> $display_source"
+        [[ "$context" == "development" ]] && info "Linked to git repo (development mode)"
+        info "You can now run 'termote' from anywhere"
+    else
+        # Try ~/.local/bin (user-writable, no sudo needed)
+        local user_bin="$HOME/.local/bin"
+        local user_target="$user_bin/termote"
+        mkdir -p "$user_bin" 2>/dev/null
+        if ln -sf "$source" "$user_target" 2>/dev/null; then
+            info "Created symlink: $user_target -> $display_source"
+            [[ "$context" == "development" ]] && info "Linked to git repo (development mode)"
+            # Check if ~/.local/bin is in PATH
+            if [[ ":$PATH:" != *":$user_bin:"* ]]; then
+                warn "\$HOME/.local/bin is not in PATH"
+                echo "Add to ~/.bashrc or ~/.zshrc:"
+                echo -e "  ${CYAN}export PATH=\"\$HOME/.local/bin:\$PATH\"${NC}"
+            else
+                info "You can now run 'termote' from anywhere"
+            fi
+        else
+            # Both failed, show manual instructions
+            warn "Cannot create symlink (no write permission)"
+            echo ""
+            echo "Run with sudo:"
+            echo -e "  ${CYAN}sudo ln -sf \"$display_source\" $target${NC}"
+        fi
+    fi
+}
+
+cmd_unlink() {
+    local removed=false
+
+    # Check both locations
+    for target in "/usr/local/bin/termote" "$HOME/.local/bin/termote"; do
+        if [[ -L "$target" ]]; then
+            local current_target
+            current_target=$(readlink "$target")
+            local display_current="${current_target/#$HOME/\$HOME}"
+            local display_target="${target/#$HOME/\$HOME}"
+
+            if rm "$target" 2>/dev/null; then
+                info "Removed symlink: $display_target"
+                removed=true
+                info "To restore: ./scripts/termote.sh link"
+                info "If 'termote' still cached, run 'hash -r' (bash) or 'rehash' (zsh)"
+            else
+                warn "Cannot remove $display_target (no write permission)"
+                echo -e "Run: ${CYAN}sudo rm $target${NC}"
+            fi
+        fi
+    done
+
+    [[ "$removed" == false ]] && info "No symlink found"
+    return 0
 }
 
 # =============================================================================
@@ -830,10 +921,12 @@ fi
 CMD="$1"; shift
 
 case "$CMD" in
-    install)  cmd_install "$@" ;;
+    install)   cmd_install "$@" ;;
     uninstall) cmd_uninstall "$@" ;;
-    health)   cmd_health ;;
-    logs)     cmd_logs "$@" ;;
+    health)    cmd_health ;;
+    logs)      cmd_logs "$@" ;;
+    link)      cmd_link ;;
+    unlink)    cmd_unlink ;;
     help|-h|--help) cmd_help ;;
     *)
         error "Unknown command: $CMD"

--- a/tests/test-termote.sh
+++ b/tests/test-termote.sh
@@ -40,6 +40,13 @@ test_syntax() {
     else
         fail "get.sh syntax" "valid bash" "syntax error"
     fi
+
+    # get.sh auto-links after install
+    if grep -q 'termote.sh link' "$PROJECT_DIR/scripts/get.sh"; then
+        pass "get.sh auto-links after install"
+    else
+        fail "get.sh auto-link" "calls termote.sh link" "not found"
+    fi
 }
 
 # =============================================================================
@@ -448,6 +455,88 @@ test_version_display() {
     fi
 }
 
+test_link_unlink() {
+    echo ""
+    echo "=== Link/Unlink Commands ==="
+
+    # cmd_link function exists
+    if grep -q 'cmd_link()' "$SCRIPT"; then
+        pass "cmd_link() function present"
+    else
+        fail "cmd_link" "function defined" "not found"
+    fi
+
+    # cmd_unlink function exists
+    if grep -q 'cmd_unlink()' "$SCRIPT"; then
+        pass "cmd_unlink() function present"
+    else
+        fail "cmd_unlink" "function defined" "not found"
+    fi
+
+    # Help shows link command
+    if grep -q 'link.*symlink' "$SCRIPT"; then
+        pass "help shows link command"
+    else
+        fail "help link" "link command in help" "not found"
+    fi
+
+    # Help shows unlink command
+    if grep -q 'unlink.*symlink' "$SCRIPT"; then
+        pass "help shows unlink command"
+    else
+        fail "help unlink" "unlink command in help" "not found"
+    fi
+
+    # Uses $HOME substitution for cleaner output
+    if grep -q '\${.*/#\$HOME' "$SCRIPT"; then
+        pass "\$HOME path substitution present"
+    else
+        fail "\$HOME substitution" "path display with \$HOME" "not found"
+    fi
+
+    # Detects git repo vs installed context
+    if grep -q 'context=.*development\|installed' "$SCRIPT"; then
+        pass "context detection (dev vs installed)"
+    else
+        fail "context detection" "dev/installed detection" "not found"
+    fi
+
+    # Fallback options when no write permission
+    if grep -q 'sudo ln -sf' "$SCRIPT"; then
+        pass "sudo fallback option present"
+    else
+        fail "sudo fallback" "sudo ln -sf suggestion" "not found"
+    fi
+
+    # Case statement includes link/unlink
+    if grep -q 'link).*cmd_link' "$SCRIPT" && grep -q 'unlink).*cmd_unlink' "$SCRIPT"; then
+        pass "link/unlink in command dispatch"
+    else
+        fail "command dispatch" "link/unlink cases" "not found"
+    fi
+
+    # Auto-fallback to ~/.local/bin
+    if grep -q '\.local/bin' "$SCRIPT"; then
+        pass "~/.local/bin fallback present"
+    else
+        fail "local bin fallback" "~/.local/bin" "not found"
+    fi
+
+    # Unlink checks both locations
+    if grep -q 'for target in.*local/bin' "$SCRIPT"; then
+        pass "unlink checks both locations"
+    else
+        fail "unlink locations" "checks /usr/local/bin and ~/.local/bin" "not found"
+    fi
+
+    # Shell cache hint (bash + zsh)
+    if grep -q 'hash -r.*bash.*rehash.*zsh' "$SCRIPT"; then
+        pass "shell cache hint (bash/zsh)"
+    else
+        fail "shell cache hint" "hash -r and rehash" "not found"
+    fi
+}
+
 echo "Running termote.sh tests..."
 echo ""
 
@@ -464,6 +553,7 @@ test_config_persistence
 test_password_encryption
 test_health_check
 test_version_display
+test_link_unlink
 
 # Summary
 echo ""

--- a/website/src/content/docs/getting-started.mdx
+++ b/website/src/content/docs/getting-started.mdx
@@ -60,7 +60,18 @@ curl -fsSL .../get.sh | bash -s -- --version 0.0.4
 ./scripts/termote.sh install native    # Native mode (host tools)
 ./scripts/termote.sh uninstall all     # Uninstall everything
 ./scripts/termote.sh health            # Check service health
+./scripts/termote.sh link              # Create 'termote' global command
+./scripts/termote.sh unlink            # Remove global command
 ```
+
+<Aside type="tip">
+  After running `link`, you can use `termote` from anywhere:
+  ```bash
+  termote health
+  termote install native --lan
+  ```
+
+</Aside>
 
 ## What's Next
 

--- a/website/src/content/docs/vi/getting-started.mdx
+++ b/website/src/content/docs/vi/getting-started.mdx
@@ -55,13 +55,23 @@ curl -fsSL .../get.sh | bash -s -- --version 0.0.4
 ## Các lệnh CLI
 
 ```bash
-./scripts/termote.sh                 # Menu tương tác
+./scripts/termote.sh                    # Menu tương tác
 ./scripts/termote.sh install container  # Chế độ Container
 ./scripts/termote.sh install native     # Chế độ Native
-./scripts/termote.sh install           # Cài đặt (dùng artifacts có sẵn)
-./scripts/termote.sh uninstall all     # Gỡ cài đặt tất cả
-./scripts/termote.sh health            # Kiểm tra sức khỏe dịch vụ
+./scripts/termote.sh uninstall all      # Gỡ cài đặt tất cả
+./scripts/termote.sh health             # Kiểm tra sức khỏe dịch vụ
+./scripts/termote.sh link               # Tạo lệnh 'termote' toàn cục
+./scripts/termote.sh unlink             # Xóa lệnh toàn cục
 ```
+
+<Aside type="tip">
+  Sau khi chạy `link`, bạn có thể dùng `termote` từ bất kỳ đâu:
+  ```bash
+  termote health
+  termote install native --lan
+  ```
+
+</Aside>
 
 ## Tiếp theo
 


### PR DESCRIPTION
## Summary

- Add `termote link` command to create global `termote` symlink
- Add `termote unlink` command to remove symlink
- Auto-link after `get.sh` installation (with backwards compatibility)

## Features

- Tries `/usr/local/bin` first, falls back to `~/.local/bin`
- Detects git repo vs installed context (shows "development mode" hint)
- Shows PATH warning if `~/.local/bin` not in PATH
- Shell cache hint (`hash -r` / `rehash`) after unlink
- Backwards compatible with older versions

## Test plan

- [x] `./scripts/termote.sh link` creates symlink
- [x] `termote help` works after linking
- [x] `./scripts/termote.sh unlink` removes symlink
- [x] Shell cache hint displayed after unlink
- [x] 64 CLI tests pass
- [x] macOS compatibility verified (readlink, ln -sf, hash/rehash)