### PR TITLE
fix(cli): resolve symlinks for global termote command

### DIFF
--- a/scripts/termote.sh
+++ b/scripts/termote.sh
@@ -10,7 +10,14 @@
 set -e
 
 VERSION="0.0.7" # x-release-please-version
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# Resolve symlinks (for `termote link` global command)
+_script_path="${BASH_SOURCE[0]}"
+while [ -L "$_script_path" ]; do
+    _link_dir="$(cd "$(dirname "$_script_path")" && pwd)"
+    _script_path="$(readlink "$_script_path")"
+    [[ "$_script_path" != /* ]] && _script_path="$_link_dir/$_script_path"
+done
+SCRIPT_DIR="$(cd "$(dirname "$_script_path")" && pwd)"
 PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
 
 # Override VERSION when running from installed location (not git repo)

--- a/tests/test-termote.sh
+++ b/tests/test-termote.sh
@@ -535,6 +535,30 @@ test_link_unlink() {
     else
         fail "shell cache hint" "hash -r and rehash" "not found"
     fi
+
+    # Symlink resolution - critical for link command to work
+    if grep -q 'while.*-L.*_script_path' "$SCRIPT" && grep -q 'readlink' "$SCRIPT"; then
+        pass "symlink resolution logic present"
+    else
+        fail "symlink resolution" "while loop with readlink" "not found"
+    fi
+
+    # Functional test: symlink resolves to correct PROJECT_DIR
+    local test_link="/tmp/termote-symlink-test-$$"
+    ln -sf "$SCRIPT" "$test_link" 2>/dev/null
+    if [ -L "$test_link" ]; then
+        # Run from /tmp, verify it finds pwa directory
+        local output
+        output=$("$test_link" health 2>&1 | head -5)
+        rm -f "$test_link"
+        if echo "$output" | grep -q "Health Check"; then
+            pass "symlink execution works from different dir"
+        else
+            fail "symlink execution" "health check output" "$output"
+        fi
+    else
+        fail "symlink creation" "create test symlink" "failed"
+    fi
 }
 
 echo "Running termote.sh tests..."


### PR DESCRIPTION
## Summary
- Fix `termote install` failing when invoked via symlink (after `termote link`)
- Add symlink resolution loop to find real script location before calculating paths
- Add regression tests for symlink execution

## Root Cause
`SCRIPT_DIR` was calculated from `${BASH_SOURCE[0]}` without resolving symlinks. When running via `/usr/local/bin/termote` symlink, `PROJECT_DIR` pointed to `/usr/local` instead of actual project root.

## Test plan
- [x] All 66 CLI tests pass
- [x] Verified symlink execution from different directory works