### PR TITLE
fix(windows): fix installer warnings and add auto-versioning

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -17,6 +17,10 @@
         {
           "type": "generic",
           "path": "scripts/termote.sh"
+        },
+        {
+          "type": "generic",
+          "path": "scripts/termote.ps1"
         }
       ]
     }

--- a/scripts/get.ps1
+++ b/scripts/get.ps1
@@ -195,8 +195,9 @@ function Main {
         # Verify checksum
         Write-Info "Verifying checksum..."
         try {
-            $checksums = (Invoke-WebRequest -Uri $checksumsUrl -UseBasicParsing).Content
-            $expectedLine = $checksums -split "`n" | Where-Object { $_ -match $tarball }
+            $response = Invoke-WebRequest -Uri $checksumsUrl -UseBasicParsing
+            $checksums = if ($response.Content -is [byte[]]) { [System.Text.Encoding]::UTF8.GetString($response.Content) } else { $response.Content }
+            $expectedLine = $checksums -split '\r?\n' | Where-Object { $_ -like "* $tarball" }
             if ($expectedLine) {
                 $expected = ($expectedLine -split '\s+')[0]
                 Test-Checksum -File $tarball -Expected $expected

--- a/scripts/termote.ps1
+++ b/scripts/termote.ps1
@@ -36,9 +36,16 @@ param(
 # CONFIGURATION
 # =============================================================================
 
-$script:VERSION = "0.0.4"
+$script:VERSION = "0.0.7" # x-release-please-version
 $script:SCRIPT_DIR = Split-Path -Parent $MyInvocation.MyCommand.Path
 $script:PROJECT_DIR = Split-Path -Parent $script:SCRIPT_DIR
+
+# Override VERSION when running from installed location (not git repo)
+$versionFile = Join-Path $script:PROJECT_DIR ".version"
+$isGitRepo = try { git -C $script:SCRIPT_DIR rev-parse --git-dir 2>$null; $LASTEXITCODE -eq 0 } catch { $false }
+if (-not $isGitRepo -and (Test-Path $versionFile)) {
+    $script:VERSION = (Get-Content $versionFile -Raw).Trim()
+}
 $script:PORT_MAIN = 7680
 $script:PORT_TTYD = 7681
 $script:CONTAINER_NAME = "termote"
@@ -428,6 +435,10 @@ function Start-ContainerMode {
         if ($buildExitCode -ne 0) { Write-Err "Cross-compilation failed" }
     }
 
+    # Ensure workspace directory exists (Docker on Windows doesn't auto-create bind mounts)
+    $workspace = Join-Path $script:PROJECT_DIR "workspace"
+    New-Item -ItemType Directory -Path $workspace -Force | Out-Null
+
     # Stop existing
     Push-Location $script:PROJECT_DIR
     try {
@@ -482,7 +493,8 @@ function Stop-ContainerMode {
 # =============================================================================
 
 function Test-Psmux {
-    if (-not (Get-Command tmux -ErrorAction SilentlyContinue)) {
+    $tmux = Get-Command tmux -ErrorAction SilentlyContinue
+    if (-not $tmux) {
         Write-Err @"
 psmux not found. Install it:
   winget install psmux
@@ -492,9 +504,8 @@ Or from: https://github.com/psmux/psmux
     }
 
     # Verify it's psmux (not WSL tmux)
-    $version = & tmux -V 2>&1
-    if ($version -notmatch "psmux") {
-        Write-Warn "tmux found but may not be psmux. Proceeding anyway."
+    if ($tmux.Source -notmatch "psmux") {
+        Write-Warn "tmux found at $($tmux.Source) but may not be psmux. Proceeding anyway."
     }
 }
 


### PR DESCRIPTION
## Summary
- Fix checksum verification failure in `get.ps1` — `Invoke-WebRequest` on PowerShell 7+ returns `byte[]` for non-text content types, causing silent match failure
- Fix false psmux warning — psmux outputs `tmux 3.3` not "psmux", now checks binary path instead
- Fix container mode `statfs` error — create workspace directory before `compose up` (Docker on Windows doesn't auto-create bind mounts)
- Add `x-release-please-version` marker and `.version` file fallback to `termote.ps1` (was stuck at `v0.0.4`)

## Test plan
- [ ] Run `irm .../get.ps1 | iex` — checksum verification should pass (no "Checksum not found" warning)
- [ ] Run `termote.ps1 install native` with psmux installed — no "may not be psmux" warning
- [ ] Run `termote.ps1 install container` — no `statfs workspace` error
- [ ] Verify `termote.ps1` shows correct version (`v0.0.7`, not `v0.0.4`)