### PR TITLE
fix(windows): change default port to 7690 to avoid DoSvc conflict

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,7 +142,7 @@ Both modes use tmux-api as the unified server (PWA + WebSocket proxy + API + aut
 
 ┌─────────────────────────────────────────────────────────┐
 │ Native mode (Windows with psmux)                        │
-│   tmux-api.exe:7680 (PWA + proxy + API + auth)          │
+│   tmux-api.exe:7690 (PWA + proxy + API + auth)          │
 │   ├→ static PWA files                                   │
 │   ├→ WebSocket proxy to ttyd:7681                       │
 │   └→ tmux API endpoints → psmux                         │

--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ flowchart LR
 | `--lan`                     | Expose to LAN (default: localhost only)         |
 | `--tailscale <host[:port]>` | Enable Tailscale HTTPS                          |
 | `--no-auth`                 | Disable basic authentication                    |
-| `--port <port>`             | Host port (default: 7680)                       |
+| `--port <port>`             | Host port (default: 7680, Windows: 7690)        |
 | `--fresh`                   | Force new password prompt (ignore saved config) |
 | `--update`                  | Auto-update with saved config                   |
 | `--version <ver>`           | Install specific version (with or without `v`)  |

--- a/README.vi.md
+++ b/README.vi.md
@@ -206,7 +206,7 @@ flowchart LR
 | `--lan`                     | Mở truy cập LAN (mặc định: chỉ localhost)       |
 | `--tailscale <host[:port]>` | Bật Tailscale HTTPS                             |
 | `--no-auth`                 | Tắt xác thực cơ bản                             |
-| `--port <port>`             | Port host (mặc định: 7680)                      |
+| `--port <port>`             | Port host (mặc định: 7680, Windows: 7690)       |
 | `--fresh`                   | Buộc nhập mật khẩu mới (bỏ qua config đã lưu)   |
 | `--update`                  | Cập nhật tự động với config đã lưu              |
 | `--version <ver>`           | Cài đặt phiên bản cụ thể (có hoặc không có `v`) |

--- a/scripts/termote.ps1
+++ b/scripts/termote.ps1
@@ -27,7 +27,7 @@ param(
 
     [switch]$Lan,
     [switch]$NoAuth,
-    [int]$Port = 7680,
+    [int]$Port = 7690,
     [string]$Tailscale,
     [switch]$Fresh
 )
@@ -46,7 +46,8 @@ $isGitRepo = try { git -C $script:SCRIPT_DIR rev-parse --git-dir 2>$null; $LASTE
 if (-not $isGitRepo -and (Test-Path $versionFile)) {
     $script:VERSION = (Get-Content $versionFile -Raw).Trim()
 }
-$script:PORT_MAIN = 7680
+$script:PORT_MAIN = 7690
+$script:PORT_CONTAINER = 7680
 $script:PORT_TTYD = 7681
 $script:CONTAINER_NAME = "termote"
 $script:HOME_DIR = if ($env:USERPROFILE) { $env:USERPROFILE } else { $env:HOME }
@@ -450,7 +451,7 @@ function Start-ContainerMode {
 services:
   termote:
     ports:
-      - "${BindAddr}:${Port}:$($script:PORT_MAIN)"
+      - "${BindAddr}:${Port}:$($script:PORT_CONTAINER)"
 "@
     $override | Out-File -FilePath "docker-compose.override.yml" -Encoding utf8 -NoNewline
 
@@ -642,7 +643,7 @@ function Invoke-Install {
 
         [switch]$Lan,
         [switch]$NoAuth,
-        [int]$Port = 7680,
+        [int]$Port = 7690,
         [string]$Tailscale,
         [switch]$Fresh
     )
@@ -792,6 +793,48 @@ function Invoke-Uninstall {
     Write-Info "Uninstall complete!"
 }
 
+function Test-ContainerEndpoint {
+    param([string]$Runtime, [int]$Port, [string]$Path, [string]$Label)
+    try {
+        $response = & $Runtime exec $script:CONTAINER_NAME curl -s -o /dev/null -w "%{http_code}" "http://127.0.0.1:${Port}${Path}" 2>$null
+        if ($response -eq "200") {
+            Write-Host "  [OK] $Label - running (container)" -ForegroundColor Green; return $true
+        } elseif ($response -eq "401") {
+            Write-Host "  [OK] $Label - running (auth, container)" -ForegroundColor Green; return $true
+        }
+        Write-Host "  [--] $Label - not running (container, HTTP $response)" -ForegroundColor Red; return $false
+    } catch {
+        Write-Host "  [--] $Label - not running (container)" -ForegroundColor Red; return $false
+    }
+}
+
+# Use raw TCP + HTTP/1.0 to avoid PS 5.1 auth negotiation hang with Invoke-WebRequest
+function Test-NativeTcpEndpoint {
+    param([int]$Port, [string]$Path, [string]$Label)
+    $tcp = $null
+    try {
+        $tcp = New-Object System.Net.Sockets.TcpClient
+        $tcp.Connect("127.0.0.1", $Port)
+        $stream = $tcp.GetStream()
+        $writer = New-Object System.IO.StreamWriter($stream)
+        $reader = New-Object System.IO.StreamReader($stream)
+        $writer.Write("GET $Path HTTP/1.0`r`nHost: localhost`r`n`r`n")
+        $writer.Flush()
+        $stream.ReadTimeout = 2000
+        $statusLine = $reader.ReadLine()
+        if ($statusLine -match "401") {
+            Write-Host "  [OK] $Label - running (auth)" -ForegroundColor Green; return $true
+        } elseif ($statusLine -match "200") {
+            Write-Host "  [OK] $Label - running" -ForegroundColor Green; return $true
+        }
+        Write-Host "  [--] $Label - unexpected status: $statusLine" -ForegroundColor Red; return $false
+    } catch {
+        Write-Host "  [--] $Label - not running" -ForegroundColor Red; return $false
+    } finally {
+        if ($tcp) { $tcp.Close() }
+    }
+}
+
 function Invoke-Health {
     Write-Host ""
     Write-Host "=== Termote Health Check ===" -ForegroundColor White
@@ -800,7 +843,7 @@ function Invoke-Health {
     $failed = 0
     $port = if ($Port -gt 0) { $Port } else { $script:PORT_MAIN }
 
-    # Check container mode
+    # Detect container mode
     $containerMode = $false
     $runtime = $null
     if (Get-Command docker -ErrorAction SilentlyContinue) {
@@ -814,77 +857,29 @@ function Invoke-Health {
 
     # Check ttyd
     if ($containerMode) {
-        try {
-            $response = & $runtime exec $script:CONTAINER_NAME curl -s -o /dev/null -w "%{http_code}" "http://127.0.0.1:$script:PORT_TTYD/" 2>$null
-            if ($response -eq "200") {
-                Write-Host "  [OK] ttyd :$script:PORT_TTYD - running (container)" -ForegroundColor Green
-            } else {
-                Write-Host "  [--] ttyd :$script:PORT_TTYD - not running (container)" -ForegroundColor Red
-                $failed++
-            }
-        } catch {
-            Write-Host "  [--] ttyd :$script:PORT_TTYD - not running (container)" -ForegroundColor Red
-            $failed++
-        }
+        if (-not (Test-ContainerEndpoint -Runtime $runtime -Port $script:PORT_TTYD -Path "/" -Label "ttyd :$($script:PORT_TTYD)")) { $failed++ }
     } else {
         try {
-            $response = Invoke-WebRequest -Uri "http://127.0.0.1:$script:PORT_TTYD/" -UseBasicParsing -TimeoutSec 2 -ErrorAction Stop
-            Write-Host "  [OK] ttyd :$script:PORT_TTYD - running" -ForegroundColor Green
+            Invoke-WebRequest -Uri "http://127.0.0.1:$script:PORT_TTYD/" -UseBasicParsing -TimeoutSec 2 -ErrorAction Stop | Out-Null
+            Write-Host "  [OK] ttyd :$($script:PORT_TTYD) - running" -ForegroundColor Green
         } catch {
-            Write-Host "  [--] ttyd :$script:PORT_TTYD - not running" -ForegroundColor Red
+            Write-Host "  [--] ttyd :$($script:PORT_TTYD) - not running" -ForegroundColor Red
             $failed++
         }
     }
 
-    # Check main server (use raw TCP + HTTP to avoid PS 5.1 auth negotiation hang)
-    $tcp = $null
-    try {
-        $tcp = New-Object System.Net.Sockets.TcpClient
-        $tcp.Connect("127.0.0.1", $port)
-        $stream = $tcp.GetStream()
-        $writer = New-Object System.IO.StreamWriter($stream)
-        $reader = New-Object System.IO.StreamReader($stream)
-        $writer.Write("GET / HTTP/1.0`r`nHost: localhost`r`n`r`n")
-        $writer.Flush()
-        $stream.ReadTimeout = 2000
-        $statusLine = $reader.ReadLine()
-        if ($statusLine -match "401") {
-            Write-Host "  [OK] tmux-api :$port - running (auth)" -ForegroundColor Green
-        } elseif ($statusLine -match "200") {
-            Write-Host "  [OK] tmux-api :$port - running" -ForegroundColor Green
+    # Check tmux-api and API endpoint (container uses internal port 7680)
+    $checkPort = if ($containerMode) { $script:PORT_CONTAINER } else { $port }
+    $checks = @(
+        @{ Path = "/"; Label = "tmux-api :$port" },
+        @{ Path = "/api/tmux/health"; Label = "API /api/tmux/health" }
+    )
+    foreach ($check in $checks) {
+        if ($containerMode) {
+            if (-not (Test-ContainerEndpoint -Runtime $runtime -Port $checkPort -Path $check.Path -Label $check.Label)) { $failed++ }
         } else {
-            Write-Host "  [??] tmux-api :$port - unexpected status: $statusLine" -ForegroundColor Yellow
+            if (-not (Test-NativeTcpEndpoint -Port $checkPort -Path $check.Path -Label $check.Label)) { $failed++ }
         }
-    } catch {
-        Write-Host "  [--] tmux-api :$port - not running" -ForegroundColor Red
-        $failed++
-    } finally {
-        if ($tcp) { $tcp.Close() }
-    }
-
-    # Check API endpoint
-    $tcp = $null
-    try {
-        $tcp = New-Object System.Net.Sockets.TcpClient
-        $tcp.Connect("127.0.0.1", $port)
-        $stream = $tcp.GetStream()
-        $writer = New-Object System.IO.StreamWriter($stream)
-        $reader = New-Object System.IO.StreamReader($stream)
-        $writer.Write("GET /api/tmux/health HTTP/1.0`r`nHost: localhost`r`n`r`n")
-        $writer.Flush()
-        $stream.ReadTimeout = 2000
-        $statusLine = $reader.ReadLine()
-        if ($statusLine -match "401") {
-            Write-Host "  [OK] API /api/tmux/health - running (auth)" -ForegroundColor Green
-        } elseif ($statusLine -match "200") {
-            Write-Host "  [OK] API /api/tmux/health - running" -ForegroundColor Green
-        } else {
-            Write-Host "  [--] API /api/tmux/health - not running" -ForegroundColor Yellow
-        }
-    } catch {
-        Write-Host "  [--] API /api/tmux/health - not running" -ForegroundColor Yellow
-    } finally {
-        if ($tcp) { $tcp.Close() }
     }
 
     Write-Host ""

--- a/tests/test-termote.ps1
+++ b/tests/test-termote.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Test suite for termote.ps1
 .DESCRIPTION
@@ -34,7 +34,7 @@ Write-Host ""
 # Determine script path
 $TestDir = if ($PSScriptRoot) { $PSScriptRoot } else { Split-Path -Parent $MyInvocation.MyCommand.Path }
 if (-not $TestDir) { $TestDir = Get-Location }
-$ScriptPath = Join-Path $TestDir ".." "scripts" "termote.ps1"
+$ScriptPath = Join-Path (Join-Path (Join-Path $TestDir "..") "scripts") "termote.ps1"
 $ScriptPath = [System.IO.Path]::GetFullPath($ScriptPath)
 if (-not (Test-Path $ScriptPath)) {
     Write-Host "[ERROR] Script not found: $ScriptPath" -ForegroundColor Red
@@ -169,6 +169,30 @@ try {
     Write-TestResult -Name "Fresh parameter defined" -Passed ($hasFreshParam -and $hasFreshUsage)
 } catch {
     Write-TestResult -Name "Fresh parameter defined" -Passed $false -Error $_.Exception.Message
+}
+
+# ─────────────────────────────────────────────────────────────
+# Test 11: Windows default port avoids DoSvc conflict (7690)
+# ─────────────────────────────────────────────────────────────
+try {
+    $content = Get-Content $ScriptPath -Raw
+    $hasPortMain = $content -match '\$script:PORT_MAIN\s*=\s*7690'
+    $hasPortContainer = $content -match '\$script:PORT_CONTAINER\s*=\s*7680'
+    Write-TestResult -Name "Windows default port 7690 (avoids DoSvc)" -Passed ($hasPortMain -and $hasPortContainer)
+} catch {
+    Write-TestResult -Name "Windows default port 7690 (avoids DoSvc)" -Passed $false -Error $_.Exception.Message
+}
+
+# ─────────────────────────────────────────────────────────────
+# Test 12: Health check helper functions exist
+# ─────────────────────────────────────────────────────────────
+try {
+    $content = Get-Content $ScriptPath -Raw
+    $hasContainerCheck = $content -match "function Test-ContainerEndpoint"
+    $hasNativeCheck = $content -match "function Test-NativeTcpEndpoint"
+    Write-TestResult -Name "Health check helpers exist" -Passed ($hasContainerCheck -and $hasNativeCheck)
+} catch {
+    Write-TestResult -Name "Health check helpers exist" -Passed $false -Error $_.Exception.Message
 }
 
 # ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Change Windows default port from 7680 to 7690 to avoid conflict with Windows Delivery Optimization service (DoSvc) which reserves port 7680
- Add `PORT_CONTAINER` constant (7680) for correct host-to-container port mapping in compose override
- Extract `Test-ContainerEndpoint` and `Test-NativeTcpEndpoint` helpers to eliminate duplicated health check code
- Fix `$failed` counter not incrementing on all failure paths in health check
- Fix `Join-Path` PS 5.1 compatibility in test script

## Test plan
- [x] `termote.ps1 health` reports all services healthy in container mode
- [x] `termote.ps1 install container` deploys on port 7690 and is accessible from browser
- [x] All 12 PowerShell tests pass (`tests/test-termote.ps1`)
- [ ] Verify native mode health check still works on Windows
- [ ] Verify Unix port 7680 default is unaffected (`scripts/termote.sh`)