### PR TITLE
fix: clean up redundant pwa-dist folder after release install

### DIFF
--- a/scripts/termote.ps1
+++ b/scripts/termote.ps1
@@ -688,6 +688,7 @@ function Invoke-Install {
             New-Item -ItemType Directory -Path $destDir -Force | Out-Null
         }
         Copy-Item -Path "$pwaDist\*" -Destination $destDir -Recurse -Force
+        Remove-Item -Path (Join-Path $script:PROJECT_DIR "pwa-dist") -Recurse -Force
     } else {
         Push-Location (Join-Path $script:PROJECT_DIR "pwa")
         & pnpm install --frozen-lockfile

--- a/scripts/termote.sh
+++ b/scripts/termote.sh
@@ -530,6 +530,7 @@ cmd_install() {
     if [[ "$RELEASE_MODE" == true ]]; then
         mkdir -p "$PROJECT_DIR/pwa/dist"
         cp -r "$PWA_DIST/"* "$PROJECT_DIR/pwa/dist/"
+        rm -rf "$PROJECT_DIR/pwa-dist"
     else
         (cd "$PROJECT_DIR/pwa" && pnpm install --frozen-lockfile && pnpm build)
     fi


### PR DESCRIPTION
## Summary
- Remove `pwa-dist/` folder after copying its contents to `pwa/dist/` during release installs
- Applies to both Unix (`termote.sh`) and Windows (`termote.ps1`) scripts
- Eliminates ~130KB of redundant files in `~/.termote`

## Test plan
- [ ] Run release install on Unix and verify `pwa-dist/` is removed after install
- [ ] Run release install on Windows and verify `pwa-dist/` is removed after install
- [ ] Verify `pwa/dist/` contains all expected PWA files after install