### PR TITLE
fix: detect release mode by checking pwa/package.json absence

### DIFF
--- a/scripts/termote.ps1
+++ b/scripts/termote.ps1
@@ -667,12 +667,10 @@ function Invoke-Install {
     $bindAddr = if ($Lan) { "0.0.0.0" } else { "127.0.0.1" }
     $lanIP = if ($Lan) { Get-LanIP } else { "" }
 
-    # Check release mode
-    $releaseMode = $false
-    $pwaDist = Join-Path $script:PROJECT_DIR "pwa\dist"
-    if (Test-Path (Join-Path $script:PROJECT_DIR "pwa-dist")) {
-        $releaseMode = $true
-        $pwaDist = Join-Path $script:PROJECT_DIR "pwa-dist"
+    # Detect release mode (no pwa/package.json means this is an installed release, not the dev repo)
+    $releaseMode = -not (Test-Path (Join-Path $script:PROJECT_DIR "pwa\package.json"))
+    $pwaDistDir = Join-Path $script:PROJECT_DIR "pwa-dist"
+    if ($releaseMode) {
         Write-Info "Release mode (using pre-built artifacts)"
     }
 
@@ -683,12 +681,17 @@ function Invoke-Install {
     # Step 1: Setup PWA
     Write-Step "1/4" "Setting up PWA..."
     if ($releaseMode) {
-        $destDir = Join-Path $script:PROJECT_DIR "pwa\dist"
-        if (-not (Test-Path $destDir)) {
-            New-Item -ItemType Directory -Path $destDir -Force | Out-Null
+        if (Test-Path $pwaDistDir) {
+            $destDir = Join-Path $script:PROJECT_DIR "pwa\dist"
+            if (-not (Test-Path $destDir)) {
+                New-Item -ItemType Directory -Path $destDir -Force | Out-Null
+            }
+            Copy-Item -Path "$pwaDistDir\*" -Destination $destDir -Recurse -Force
+            Remove-Item -Path $pwaDistDir -Recurse -Force
+        } elseif (-not (Test-Path (Join-Path $script:PROJECT_DIR "pwa\dist"))) {
+            Write-Err "PWA dist not found. Please reinstall from a release."
+            return
         }
-        Copy-Item -Path "$pwaDist\*" -Destination $destDir -Recurse -Force
-        Remove-Item -Path (Join-Path $script:PROJECT_DIR "pwa-dist") -Recurse -Force
     } else {
         Push-Location (Join-Path $script:PROJECT_DIR "pwa")
         & pnpm install --frozen-lockfile

--- a/scripts/termote.sh
+++ b/scripts/termote.sh
@@ -505,14 +505,10 @@ cmd_install() {
     parse_cmd_opts "$@"
     [[ "$FRESH" != true ]] && load_config
 
-    # Check if release mode (pre-built artifacts)
+    # Detect release mode (no pwa/package.json means this is an installed release, not the dev repo)
     local RELEASE_MODE=false
-    local PWA_DIST="$PROJECT_DIR/pwa/dist"
-    if [[ -d "$PROJECT_DIR/pwa-dist" ]]; then
-        RELEASE_MODE=true
-        PWA_DIST="$PROJECT_DIR/pwa-dist"
-        info "Release mode (using pre-built artifacts)"
-    fi
+    [[ ! -f "$PROJECT_DIR/pwa/package.json" ]] && RELEASE_MODE=true
+    [[ "$RELEASE_MODE" == true ]] && info "Release mode (using pre-built artifacts)"
 
     # Stop running services to avoid port conflicts and "Text file busy" on binary overwrite
     stop_native_services
@@ -528,9 +524,14 @@ cmd_install() {
     # Setup PWA
     step "1/4" "Setting up PWA..."
     if [[ "$RELEASE_MODE" == true ]]; then
-        mkdir -p "$PROJECT_DIR/pwa/dist"
-        cp -r "$PWA_DIST/"* "$PROJECT_DIR/pwa/dist/"
-        rm -rf "$PROJECT_DIR/pwa-dist"
+        if [[ -d "$PROJECT_DIR/pwa-dist" ]]; then
+            mkdir -p "$PROJECT_DIR/pwa/dist"
+            cp -r "$PROJECT_DIR/pwa-dist/"* "$PROJECT_DIR/pwa/dist/"
+            rm -rf "$PROJECT_DIR/pwa-dist"
+        elif [[ ! -d "$PROJECT_DIR/pwa/dist" ]]; then
+            err "PWA dist not found. Please reinstall from a release."
+            return 1
+        fi
     else
         (cd "$PROJECT_DIR/pwa" && pnpm install --frozen-lockfile && pnpm build)
     fi


### PR DESCRIPTION
## Summary
- Simplify release mode detection: check for `pwa/package.json` absence instead of relying on `pwa-dist/` folder (which is deleted after first install)
- Fix subsequent release installs failing with `pnpm` errors because `pwa-dist/` no longer exists
- Add error message if `pwa/dist` is missing on subsequent installs instead of silently serving a broken PWA
- Remove dead variables (`$pwaDist` / `PWA_DIST`) and redundant existence checks

## Test plan
- [ ] Fresh release install (with `pwa-dist/`): should copy to `pwa/dist/`, delete `pwa-dist/`, and proceed
- [ ] Subsequent release install (no `pwa-dist/`, existing `pwa/dist/`): should skip copy and proceed
- [ ] Subsequent release install with deleted `pwa/dist/`: should show error and abort
- [ ] Dev repo install (has `pwa/package.json`): should run `pnpm install` + `pnpm build` as before
- [ ] Verify both Unix (`termote.sh`) and Windows (`termote.ps1`) scripts