### PR TITLE
fix(windows): prevent get.ps1 from closing PowerShell tab on exit

### DIFF
--- a/scripts/get.ps1
+++ b/scripts/get.ps1
@@ -47,7 +47,7 @@ if ($Update) { $Yes = $true }
 # UI Helpers
 function Write-Info { param([string]$Message) Write-Host "[INFO] $Message" -ForegroundColor Green }
 function Write-Warn { param([string]$Message) Write-Host "[WARN] $Message" -ForegroundColor Yellow }
-function Write-Err { param([string]$Message) Write-Host "[ERROR] $Message" -ForegroundColor Red; exit 1 }
+function Write-Err { param([string]$Message) Write-Host "[ERROR] $Message" -ForegroundColor Red; $script:HandledError = $true; throw }
 
 # Load saved config for -Update mode
 function Get-SavedConfig {
@@ -164,7 +164,7 @@ function Main {
     if (-not $Yes -and -not $DownloadOnly) {
         if (-not (Confirm-Install -Current $currentVersion -Latest $latestVersion)) {
             Write-Info "Cancelled."
-            exit 0
+            return
         }
     }
 
@@ -259,4 +259,6 @@ function Main {
     }
 }
 
-Main
+try { Main } catch {
+    if (-not $script:HandledError) { throw $_ }
+}


### PR DESCRIPTION
## Summary
- When running `irm https://...get.ps1 | iex` and declining the install prompt (pressing N), the entire PowerShell tab closes instead of returning to the prompt
- Root cause: `exit` inside `irm | iex` context terminates the PowerShell host process, not just the script
- Replace `exit 0` with `return` for clean exits, and `exit 1` with `throw` + a script-scoped `$HandledError` flag for error exits

## Test plan
- [ ] Run `irm https://raw.githubusercontent.com/lamngockhuong/termote/main/scripts/get.ps1 | iex` and press N at "Re-install?" — tab should stay open
- [ ] Run the installer and trigger an error path (e.g., disconnect network) — tab should stay open with error message displayed
- [ ] Run with `$env:TERMOTE_AUTO_YES = "true"` — normal install flow should work unchanged