### PR TITLE
fix(windows): enable LAN access for container mode via netsh portproxy

### DIFF
--- a/scripts/termote.ps1
+++ b/scripts/termote.ps1
@@ -405,7 +405,6 @@ function Show-InteractiveUninstall {
 
 function Start-ContainerMode {
     param(
-        [string]$BindAddr,
         [int]$Port,
         [switch]$Lan
     )
@@ -414,7 +413,6 @@ function Start-ContainerMode {
     Write-Info "Using $runtime"
 
     # Validate inputs
-    if (-not (Test-ValidIP $BindAddr)) { Write-Err "Invalid bind address: $BindAddr" }
     if (-not (Test-ValidPort $Port)) { Write-Err "Invalid port: $Port" }
 
     # Build or copy tmux-api for Linux (container is always Linux)
@@ -466,17 +464,26 @@ services:
     Remove-Item "docker-compose.override.yml" -ErrorAction SilentlyContinue
 
     # On Windows, container port forwarding via WSL2/Hyper-V only listens on localhost.
-    # Use netsh portproxy to expose the port to LAN (requires elevation).
+    # Use netsh portproxy + firewall rule to expose the port to LAN (requires elevation).
     if ($Lan) {
         Write-Info "Setting up LAN port forwarding (netsh portproxy)..."
         $cmds = "netsh interface portproxy delete v4tov4 listenport=$Port listenaddress=0.0.0.0 2>`$null; " +
-                "netsh interface portproxy add v4tov4 listenport=$Port listenaddress=0.0.0.0 connectport=$Port connectaddress=127.0.0.1"
+                "netsh interface portproxy add v4tov4 listenport=$Port listenaddress=0.0.0.0 connectport=$Port connectaddress=127.0.0.1; " +
+                "netsh advfirewall firewall delete rule name=`"Termote LAN`" 2>`$null; " +
+                "netsh advfirewall firewall add rule name=`"Termote LAN`" dir=in action=allow protocol=tcp localport=$Port"
         try {
             Start-Process powershell -Verb RunAs -ArgumentList "-NoProfile -Command `"$cmds`"" -Wait -WindowStyle Hidden
-            Write-Info "LAN port forwarding enabled on port $Port"
+            # Verify portproxy was actually created
+            $verify = netsh interface portproxy show v4tov4 2>$null
+            if ($verify -match "$Port") {
+                Write-Info "LAN port forwarding enabled on port $Port"
+            } else {
+                Write-Warn "Port forwarding may not have been set up correctly"
+            }
         } catch {
             Write-Warn "Failed to set up LAN port forwarding. Manually run as Administrator:"
             Write-Warn "  netsh interface portproxy add v4tov4 listenport=$Port listenaddress=0.0.0.0 connectport=$Port connectaddress=127.0.0.1"
+            Write-Warn "  netsh advfirewall firewall add rule name=`"Termote LAN`" dir=in action=allow protocol=tcp localport=$Port"
         }
     }
 
@@ -505,14 +512,18 @@ function Stop-ContainerMode {
         Pop-Location
     }
 
-    # Clean up LAN port forwarding if it was set up
+    # Clean up LAN port forwarding if it exists
     $savedConfig = Get-SavedConfig
     if ($savedConfig -and $savedConfig.Lan -and $savedConfig.Mode -eq "container") {
         $port = if ($savedConfig.Port) { $savedConfig.Port } else { $script:PORT_MAIN }
-        $cmd = "netsh interface portproxy delete v4tov4 listenport=$port listenaddress=0.0.0.0 2>`$null"
-        try {
-            Start-Process powershell -Verb RunAs -ArgumentList "-NoProfile -Command `"$cmd`"" -Wait -WindowStyle Hidden
-        } catch {}
+        $verify = netsh interface portproxy show v4tov4 2>$null
+        if ($verify -match "$port") {
+            $cmd = "netsh interface portproxy delete v4tov4 listenport=$port listenaddress=0.0.0.0 2>`$null; " +
+                   "netsh advfirewall firewall delete rule name=`"Termote LAN`" 2>`$null"
+            try {
+                Start-Process powershell -Verb RunAs -ArgumentList "-NoProfile -Command `"$cmd`"" -Wait -WindowStyle Hidden
+            } catch {}
+        }
     }
 }
 
@@ -762,7 +773,7 @@ function Invoke-Install {
 
     switch ($Mode) {
         "container" {
-            Start-ContainerMode -BindAddr $bindAddr -Port $Port -Lan:$Lan
+            Start-ContainerMode -Port $Port -Lan:$Lan
         }
         "native" {
             Start-NativeMode -BindAddr $bindAddr -Port $Port -NoAuth:$NoAuth


### PR DESCRIPTION
## Summary
- On Windows, container runtimes (Docker/Podman) use WSL2/Hyper-V which only forwards ports to localhost, making `-Lan` ineffective for container mode
- Container port mapping now always binds to `127.0.0.1`, and when `-Lan` is specified, `netsh interface portproxy` forwards `0.0.0.0:port` to `127.0.0.1:port`
- Portproxy rule is auto-elevated via UAC prompt and cleaned up on `uninstall container`

## Test plan
- [x] `.\scripts\termote.ps1 install container -Lan` — UAC prompt appears, LAN access works from another device
- [ ] `.\scripts\termote.ps1 install container` (without -Lan) — works as before, localhost only
- [ ] `.\scripts\termote.ps1 uninstall container` — portproxy rule is removed
- [ ] `.\scripts\termote.ps1 install native -Lan` — unchanged, still works