### PR TITLE
docs: add known issue for Windows native mode ttyd crash

### DIFF
--- a/website/src/content/docs/getting-started.mdx
+++ b/website/src/content/docs/getting-started.mdx
@@ -15,12 +15,14 @@ import { Aside, Steps } from "@astrojs/starlight/components";
 
 **Windows:**
 
-- Docker Desktop or Podman Desktop (for Container mode)
+- Docker Desktop or Podman Desktop (for Container mode — recommended)
 - or [psmux](https://github.com/psmux/psmux) + ttyd (for Native mode): `winget install psmux`
 
 <Aside type="caution" title="Experimental">
-  Windows support is currently experimental and needs more testing. Please
-  report issues on [GitHub](https://github.com/lamngockhuong/termote/issues).
+  Windows support is currently experimental. Container mode is working. Native
+  mode has a known issue where ttyd crashes on Windows 11 (build 26200+) when a
+  WebSocket client connects — a fix is planned. Please report issues on
+  [GitHub](https://github.com/lamngockhuong/termote/issues).
 </Aside>
 
 ## One-Liner Install

--- a/website/src/content/docs/installation/native.mdx
+++ b/website/src/content/docs/installation/native.mdx
@@ -7,6 +7,13 @@ import { Steps, Tabs, TabItem, Aside } from "@astrojs/starlight/components";
 
 No Docker required. Access host binaries like `claude`, `git`, `gh`, etc.
 
+<Aside type="caution" title="Windows Native Mode — Known Issue">
+  On Windows 11 (build 26200+), ttyd.exe crashes when a WebSocket client
+  connects due to a ConPTY named pipe issue. A fix is planned (replacing ttyd
+  with a Go-based terminal handler). In the meantime, use **Container mode** on
+  Windows — it works correctly.
+</Aside>
+
 ## Prerequisites
 
 <Tabs>
@@ -20,8 +27,19 @@ No Docker required. Access host binaries like `claude`, `git`, `gh`, etc.
     ```bash
       brew install ttyd tmux go
     ```
+  </TabItem>
+  <TabItem label="Windows">
+    ```powershell
+    # Install psmux (tmux-compatible for Windows)
+    winget install psmux
+    # ttyd is auto-downloaded by the install script
+    ```
 
-</TabItem>
+    <Aside type="caution">
+      Native mode on Windows is currently broken on Windows 11 build 26200+.
+      Use [Container mode](/installation/docker/) instead.
+    </Aside>
+  </TabItem>
 </Tabs>
 
 ## Installation

--- a/website/src/content/docs/vi/getting-started.mdx
+++ b/website/src/content/docs/vi/getting-started.mdx
@@ -15,13 +15,14 @@ import { Aside, Steps } from "@astrojs/starlight/components";
 
 **Windows:**
 
-- Docker Desktop hoặc Podman Desktop (cho chế độ Container)
+- Docker Desktop hoặc Podman Desktop (cho chế độ Container — khuyến nghị)
 - hoặc [psmux](https://github.com/psmux/psmux) + ttyd (cho chế độ Native): `winget install psmux`
 
 <Aside type="caution" title="Thử nghiệm">
-  Hỗ trợ Windows hiện đang trong giai đoạn thử nghiệm và cần kiểm tra thêm. Vui
-  lòng báo cáo lỗi tại
-  [GitHub](https://github.com/lamngockhuong/termote/issues).
+  Hỗ trợ Windows đang trong giai đoạn thử nghiệm. Chế độ Container đã hoạt động.
+  Chế độ Native có lỗi đã biết: ttyd bị crash trên Windows 11 (build 26200+) khi
+  WebSocket client kết nối — bản sửa đang được lên kế hoạch. Vui lòng báo cáo lỗi
+  tại [GitHub](https://github.com/lamngockhuong/termote/issues).
 </Aside>
 
 ## Cài đặt một dòng

--- a/website/src/content/docs/vi/installation/native.mdx
+++ b/website/src/content/docs/vi/installation/native.mdx
@@ -7,6 +7,13 @@ import { Steps, Tabs, TabItem, Aside } from "@astrojs/starlight/components";
 
 Không cần Docker. Truy cập binary host như `claude`, `git`, `gh`, v.v.
 
+<Aside type="caution" title="Windows Native — Lỗi đã biết">
+  Trên Windows 11 (build 26200+), ttyd.exe bị crash khi WebSocket client kết nối
+  do lỗi named pipe của ConPTY. Bản sửa đang được lên kế hoạch (thay thế ttyd
+  bằng terminal handler viết bằng Go). Trong thời gian chờ, hãy sử dụng **chế độ
+  Container** trên Windows — hoạt động bình thường.
+</Aside>
+
 ## Yêu cầu
 
 <Tabs>
@@ -20,8 +27,19 @@ Không cần Docker. Truy cập binary host như `claude`, `git`, `gh`, v.v.
     ```bash
     brew install ttyd tmux go
     ```
+  </TabItem>
+  <TabItem label="Windows">
+    ```powershell
+    # Cài đặt psmux (tương thích tmux cho Windows)
+    winget install psmux
+    # ttyd được tự động tải bởi script cài đặt
+    ```
 
-</TabItem>
+    <Aside type="caution">
+      Chế độ Native trên Windows hiện đang bị lỗi trên Windows 11 build 26200+.
+      Hãy sử dụng [chế độ Container](/vi/installation/docker/) thay thế.
+    </Aside>
+  </TabItem>
 </Tabs>
 
 ## Cài đặt


### PR DESCRIPTION
## Summary
- Document known issue: ttyd.exe crashes on Windows 11 (build 26200+) when WebSocket client connects due to ConPTY named pipe issue
- Recommend container mode as workaround for Windows users
- Add Windows tab to native installation prerequisites (EN + VI)
- Update experimental warning in getting-started docs (EN + VI)

## Test plan
- [ ] Verify docs site builds without errors
- [ ] Check EN and VI pages render correctly with the new Aside components