### PR TITLE
fix: skip cross-compile in release mode when pre-built binary exists

### DIFF
--- a/scripts/termote.sh
+++ b/scripts/termote.sh
@@ -330,8 +330,8 @@ start_docker_mode() {
     # Warn about sensitive directories in WORKSPACE
     warn_sensitive_dirs
 
-    # Cross-compile for Linux on macOS
-    if [[ "$OS" != "Linux" ]]; then
+    # Cross-compile for Linux on macOS (skip if pre-built binary exists from release mode)
+    if [[ "$OS" != "Linux" && ! -f "$PROJECT_DIR/tmux-api/tmux-api" ]]; then
         info "Cross-compiling tmux-api (linux/$ARCH)..."
         (cd "$PROJECT_DIR/tmux-api" && CGO_ENABLED=0 GOOS=linux GOARCH="$ARCH" go build -ldflags="-s -w" -o tmux-api .) || error "Build failed"
     fi


### PR DESCRIPTION
## Summary
- `start_docker_mode()` unconditionally cross-compiled tmux-api on non-Linux, even in release mode where the pre-built binary was already placed by step 2/4
- Release installs lack Go source (`go.mod`), causing `go build` to fail
- Fix: skip cross-compile if `tmux-api/tmux-api` binary already exists

## Test plan
- [ ] `./scripts/termote.sh install container` in release mode (no `pwa/package.json`)
- [ ] `./scripts/termote.sh install container` in dev mode (with Go source)