### PR TITLE
docs: add Windows PowerShell instructions to installation guides

### DIFF
--- a/website/src/content/docs/installation/docker.mdx
+++ b/website/src/content/docs/installation/docker.mdx
@@ -3,7 +3,7 @@ title: Container Installation
 description: All-in-one container deployment
 ---
 
-import { Aside, Steps } from "@astrojs/starlight/components";
+import { Aside, Steps, Tabs, TabItem } from "@astrojs/starlight/components";
 
 Single container with tmux-api (PWA + proxy) + ttyd + tmux.
 
@@ -11,16 +11,36 @@ Single container with tmux-api (PWA + proxy) + ttyd + tmux.
 
 <Steps>
 1. Run deploy command
-   ```bash
-   ./scripts/termote.sh install container
-   ```
+
+   <Tabs>
+     <TabItem label="Unix (macOS/Linux)">
+       ```bash
+       ./scripts/termote.sh install container
+       ```
+     </TabItem>
+     <TabItem label="Windows (PowerShell)">
+       ```powershell
+       .\scripts\termote.ps1 install container
+       ```
+     </TabItem>
+   </Tabs>
 
 2. Access at http://localhost:7680
 
 3. (Optional) Expose to LAN
-   ```bash
-   ./scripts/termote.sh install container --lan
-   ```
+
+   <Tabs>
+     <TabItem label="Unix (macOS/Linux)">
+       ```bash
+       ./scripts/termote.sh install container --lan
+       ```
+     </TabItem>
+     <TabItem label="Windows (PowerShell)">
+       ```powershell
+       .\scripts\termote.ps1 install container -Lan
+       ```
+     </TabItem>
+   </Tabs>
 
 </Steps>
 
@@ -48,14 +68,28 @@ docker run -d --name termote -p 7680:7680 \
 
 ## Options
 
-| Flag              | Description                              |
-| ----------------- | ---------------------------------------- |
-| `--lan`           | Expose to LAN (default: localhost)       |
-| `--no-auth`       | Disable basic auth                       |
-| `--port <port>`   | Custom port (default: 7680)              |
-| `--fresh`         | Force new password prompt (ignore saved) |
-| `--update`        | Auto-update with saved config            |
-| `--version <ver>` | Install specific version                 |
+<Tabs>
+  <TabItem label="Unix (macOS/Linux)">
+    | Flag              | Description                              |
+    | ----------------- | ---------------------------------------- |
+    | `--lan`           | Expose to LAN (default: localhost)       |
+    | `--no-auth`       | Disable basic auth                       |
+    | `--port <port>`   | Custom port (default: 7680)              |
+    | `--fresh`         | Force new password prompt (ignore saved) |
+    | `--update`        | Auto-update with saved config            |
+    | `--version <ver>` | Install specific version                 |
+  </TabItem>
+  <TabItem label="Windows (PowerShell)">
+    | Flag              | Description                              |
+    | ----------------- | ---------------------------------------- |
+    | `-Lan`            | Expose to LAN (default: localhost)       |
+    | `-NoAuth`         | Disable basic auth                       |
+    | `-Port <port>`    | Custom port (default: 7680)              |
+    | `-Fresh`          | Force new password prompt (ignore saved) |
+
+    Online installer flags: `$env:TERMOTE_UPDATE="true"` for auto-update.
+  </TabItem>
+</Tabs>
 
 <Aside type="tip">
   Scripts auto-detect `podman` or `docker` - both work identically.
@@ -90,10 +124,20 @@ pkill caffeinate
 
 ### Quick Diagnostics
 
-```bash
-./scripts/termote.sh health   # Health check
-docker ps -a | grep termote   # Check container status
-```
+<Tabs>
+  <TabItem label="Unix (macOS/Linux)">
+    ```bash
+    ./scripts/termote.sh health   # Health check
+    docker ps -a | grep termote   # Check container status
+    ```
+  </TabItem>
+  <TabItem label="Windows (PowerShell)">
+    ```powershell
+    .\scripts\termote.ps1 health   # Health check
+    docker ps -a | Select-String termote   # Check container status
+    ```
+  </TabItem>
+</Tabs>
 
 ### View Logs
 
@@ -107,16 +151,32 @@ podman logs termote
 
 ### Container won't start
 
-```bash
-# Check startup errors
-docker logs termote
+<Tabs>
+  <TabItem label="Unix (macOS/Linux)">
+    ```bash
+    # Check startup errors
+    docker logs termote
 
-# Port already in use?
-lsof -i :7680
+    # Port already in use?
+    lsof -i :7680
 
-# Use different port
-./scripts/termote.sh install container --port 7690
-```
+    # Use different port
+    ./scripts/termote.sh install container --port 7690
+    ```
+  </TabItem>
+  <TabItem label="Windows (PowerShell)">
+    ```powershell
+    # Check startup errors
+    docker logs termote
+
+    # Port already in use?
+    netstat -ano | Select-String 7680
+
+    # Use different port
+    .\scripts\termote.ps1 install container -Port 7690
+    ```
+  </TabItem>
+</Tabs>
 
 ### Debug inside container
 
@@ -140,13 +200,26 @@ curl localhost:7680/api/tmux/health
 
 ### Restart / Reset
 
-```bash
-docker restart termote
+<Tabs>
+  <TabItem label="Unix (macOS/Linux)">
+    ```bash
+    docker restart termote
 
-# Full reset
-./scripts/termote.sh uninstall container
-./scripts/termote.sh install container
-```
+    # Full reset
+    ./scripts/termote.sh uninstall container
+    ./scripts/termote.sh install container
+    ```
+  </TabItem>
+  <TabItem label="Windows (PowerShell)">
+    ```powershell
+    docker restart termote
+
+    # Full reset
+    .\scripts\termote.ps1 uninstall container
+    .\scripts\termote.ps1 install container
+    ```
+  </TabItem>
+</Tabs>
 
 ### API Test
 
@@ -161,32 +234,61 @@ curl -u admin:password http://localhost:7680/api/tmux/sessions
 
 Re-run the installer - it compares versions and prompts before updating:
 
-```bash
-# Auto-update with saved config
-curl -fsSL https://raw.githubusercontent.com/lamngockhuong/termote/main/scripts/get.sh | bash -s -- --update
+<Tabs>
+  <TabItem label="Unix (macOS/Linux)">
+    ```bash
+    # Auto-update with saved config
+    curl -fsSL https://raw.githubusercontent.com/lamngockhuong/termote/main/scripts/get.sh | bash -s -- --update
 
-# Or without saved config
-curl -fsSL https://raw.githubusercontent.com/lamngockhuong/termote/main/scripts/get.sh | bash -s -- --container
-```
+    # Or without saved config
+    curl -fsSL https://raw.githubusercontent.com/lamngockhuong/termote/main/scripts/get.sh | bash -s -- --container
+    ```
 
-Options:
+    Options: `--update`, `--yes`, `--download-only`, `--fresh`, `--strict`
+  </TabItem>
+  <TabItem label="Windows (PowerShell)">
+    ```powershell
+    # Auto-update with saved config
+    $env:TERMOTE_UPDATE="true"; irm https://raw.githubusercontent.com/lamngockhuong/termote/main/scripts/get.ps1 | iex
 
-- `--update` - Auto-update using saved config (mode, flags, password)
-- `--yes` - Auto-update without prompt
-- `--download-only` - Download only, no install
-- `--fresh` - Force new password prompt
-- `--strict` - Require checksum verification (fail if unavailable)
+    # Or without saved config
+    $env:TERMOTE_MODE="container"; irm https://raw.githubusercontent.com/lamngockhuong/termote/main/scripts/get.ps1 | iex
+    ```
+
+    Options: `$env:TERMOTE_UPDATE="true"`, `$env:TERMOTE_AUTO_YES="true"`, `$env:TERMOTE_MODE="container"`
+  </TabItem>
+</Tabs>
 
 ### Manual Update
 
-```bash
-./scripts/termote.sh uninstall container
-git pull origin main
-./scripts/termote.sh install container
-```
+<Tabs>
+  <TabItem label="Unix (macOS/Linux)">
+    ```bash
+    ./scripts/termote.sh uninstall container
+    git pull origin main
+    ./scripts/termote.sh install container
+    ```
+  </TabItem>
+  <TabItem label="Windows (PowerShell)">
+    ```powershell
+    .\scripts\termote.ps1 uninstall container
+    git pull origin main
+    .\scripts\termote.ps1 install container
+    ```
+  </TabItem>
+</Tabs>
 
 ## Uninstall
 
-```bash
-./scripts/termote.sh uninstall container
-```
+<Tabs>
+  <TabItem label="Unix (macOS/Linux)">
+    ```bash
+    ./scripts/termote.sh uninstall container
+    ```
+  </TabItem>
+  <TabItem label="Windows (PowerShell)">
+    ```powershell
+    .\scripts\termote.ps1 uninstall container
+    ```
+  </TabItem>
+</Tabs>

--- a/website/src/content/docs/installation/native.mdx
+++ b/website/src/content/docs/installation/native.mdx
@@ -25,7 +25,7 @@ No Docker required. Access host binaries like `claude`, `git`, `gh`, etc.
   </TabItem>
   <TabItem label="macOS">
     ```bash
-      brew install ttyd tmux go
+    brew install ttyd tmux go
     ```
   </TabItem>
   <TabItem label="Windows">
@@ -49,9 +49,18 @@ No Docker required. Access host binaries like `claude`, `git`, `gh`, etc.
 
 2. Run deploy command
 
-   ```bash
-   ./scripts/termote.sh install native
-   ```
+   <Tabs>
+     <TabItem label="Unix (macOS/Linux)">
+       ```bash
+       ./scripts/termote.sh install native
+       ```
+     </TabItem>
+     <TabItem label="Windows (PowerShell)">
+       ```powershell
+       .\scripts\termote.ps1 install native
+       ```
+     </TabItem>
+   </Tabs>
 
 3. Access at http://localhost:7680
 
@@ -70,14 +79,27 @@ No Docker required. Access host binaries like `claude`, `git`, `gh`, etc.
 
 ## Service Management
 
-```bash
-# Check processes
-ps aux | grep ttyd
-ps aux | grep tmux-api
+<Tabs>
+  <TabItem label="Unix (macOS/Linux)">
+    ```bash
+    # Check processes
+    ps aux | grep ttyd
+    ps aux | grep tmux-api
 
-# Restart
-./scripts/termote.sh install native
-```
+    # Restart
+    ./scripts/termote.sh install native
+    ```
+  </TabItem>
+  <TabItem label="Windows (PowerShell)">
+    ```powershell
+    # Check processes
+    Get-Process -Name ttyd, tmux-api -ErrorAction SilentlyContinue
+
+    # Restart
+    .\scripts\termote.ps1 install native
+    ```
+  </TabItem>
+</Tabs>
 
 ## Prevent macOS Sleep
 
@@ -103,54 +125,106 @@ pkill caffeinate
 
 ### Quick Diagnostics
 
-```bash
-./scripts/termote.sh health   # Health check
-ss -tlnp | grep -E "7680|7681"  # Check ports
-```
+<Tabs>
+  <TabItem label="Unix (macOS/Linux)">
+    ```bash
+    ./scripts/termote.sh health   # Health check
+    ss -tlnp | grep -E "7680|7681"  # Check ports
+    ```
+  </TabItem>
+  <TabItem label="Windows (PowerShell)">
+    ```powershell
+    .\scripts\termote.ps1 health   # Health check
+    netstat -ano | Select-String "7680|7681"  # Check ports
+    ```
+  </TabItem>
+</Tabs>
 
 ### Check Processes
 
-```bash
-ps aux | grep ttyd         # Check if ttyd is running
-ps aux | grep tmux-api     # Check if tmux-api is running
-lsof -i :7680              # Verify main port
-lsof -i :7681              # Verify ttyd port
-```
+<Tabs>
+  <TabItem label="Unix (macOS/Linux)">
+    ```bash
+    ps aux | grep ttyd         # Check if ttyd is running
+    ps aux | grep tmux-api     # Check if tmux-api is running
+    lsof -i :7680              # Verify main port
+    lsof -i :7681              # Verify ttyd port
+    ```
+  </TabItem>
+  <TabItem label="Windows (PowerShell)">
+    ```powershell
+    Get-Process -Name ttyd, tmux-api -ErrorAction SilentlyContinue
+    netstat -ano | Select-String "7680"   # Verify main port
+    netstat -ano | Select-String "7681"   # Verify ttyd port
+    ```
+  </TabItem>
+</Tabs>
 
 ### Debug with Logs
 
-Native mode discards logs by default. To see logs:
+<Tabs>
+  <TabItem label="Unix (macOS/Linux)">
+    Native mode discards logs by default. To see logs:
 
-```bash
-# Stop services
-./scripts/termote.sh uninstall native
+    ```bash
+    # Stop services
+    ./scripts/termote.sh uninstall native
 
-# Start ttyd with logs (terminal 1)
-ttyd -W -i lo -p 7681 tmux new-session -A -s main
+    # Start ttyd with logs (terminal 1)
+    ttyd -W -i lo -p 7681 tmux new-session -A -s main
 
-# Start tmux-api with logs (terminal 2)
-cd tmux-api
-TERMOTE_PORT=7680 TERMOTE_BIND=127.0.0.1 \
-TERMOTE_PWA_DIR=../pwa/dist ./tmux-api-native
-```
+    # Start tmux-api with logs (terminal 2)
+    cd tmux-api
+    TERMOTE_PORT=7680 TERMOTE_BIND=127.0.0.1 \
+    TERMOTE_PWA_DIR=../pwa/dist ./tmux-api-native
+    ```
+  </TabItem>
+  <TabItem label="Windows (PowerShell)">
+    Native mode discards logs by default. To see logs:
+
+    ```powershell
+    # Stop services
+    .\scripts\termote.ps1 uninstall native
+
+    # Start ttyd with logs (terminal 1)
+    ttyd -W -i 127.0.0.1 -p 7681 psmux
+
+    # Start tmux-api with logs (terminal 2)
+    cd tmux-api
+    $env:TERMOTE_PORT=7680; $env:TERMOTE_BIND="127.0.0.1"
+    $env:TERMOTE_PWA_DIR="../pwa/dist"; .\tmux-api.exe
+    ```
+  </TabItem>
+</Tabs>
 
 ### Common Issues
 
 | Issue           | Solution                                          |
 | --------------- | ------------------------------------------------- |
-| Port in use     | `lsof -i :7680` then kill process                 |
-| ttyd missing    | `brew install ttyd` (macOS) or `apt install ttyd` |
+| Port in use     | `lsof -i :7680` (Unix) or `netstat -ano \| Select-String 7680` (Win) then kill process |
+| ttyd missing    | `brew install ttyd` (macOS) or `apt install ttyd` (Linux) |
 | Binary missing  | `cd tmux-api && go build -o tmux-api-native .`    |
 | PWA not built   | `cd pwa && pnpm build`                            |
 | Stale PWA cache | Settings → "Clear Cache & Reload" to refresh      |
 
-### tmux Session
+### tmux / psmux Session
 
-```bash
-tmux list-sessions         # List sessions
-tmux attach -t main        # Attach to session
-tmux kill-session -t main  # Reset session
-```
+<Tabs>
+  <TabItem label="Unix (macOS/Linux)">
+    ```bash
+    tmux list-sessions         # List sessions
+    tmux attach -t main        # Attach to session
+    tmux kill-session -t main  # Reset session
+    ```
+  </TabItem>
+  <TabItem label="Windows (PowerShell)">
+    ```powershell
+    psmux list-sessions         # List sessions
+    psmux attach -t main        # Attach to session
+    psmux kill-session -t main  # Reset session
+    ```
+  </TabItem>
+</Tabs>
 
 ### API Test
 
@@ -165,33 +239,61 @@ curl http://localhost:7680/api/tmux/sessions
 
 Re-run the installer - it compares versions and prompts before updating:
 
-```bash
-# Auto-update with saved config
-curl -fsSL https://raw.githubusercontent.com/lamngockhuong/termote/main/scripts/get.sh | bash -s -- --update
+<Tabs>
+  <TabItem label="Unix (macOS/Linux)">
+    ```bash
+    # Auto-update with saved config
+    curl -fsSL https://raw.githubusercontent.com/lamngockhuong/termote/main/scripts/get.sh | bash -s -- --update
 
-# Or standard update
-curl -fsSL https://raw.githubusercontent.com/lamngockhuong/termote/main/scripts/get.sh | bash
-```
+    # Or standard update
+    curl -fsSL https://raw.githubusercontent.com/lamngockhuong/termote/main/scripts/get.sh | bash
+    ```
 
-Options:
+    Options: `--update`, `--yes`, `--download-only`, `--fresh`, `--version <ver>`, `--strict`
+  </TabItem>
+  <TabItem label="Windows (PowerShell)">
+    ```powershell
+    # Auto-update with saved config
+    $env:TERMOTE_UPDATE="true"; irm https://raw.githubusercontent.com/lamngockhuong/termote/main/scripts/get.ps1 | iex
 
-- `--update` - Auto-update using saved config (mode, flags, password)
-- `--yes` - Auto-update without prompt
-- `--download-only` - Download only, no install
-- `--fresh` - Force new password prompt
-- `--version <ver>` - Install specific version
-- `--strict` - Require checksum verification (fail if unavailable)
+    # Or standard update
+    irm https://raw.githubusercontent.com/lamngockhuong/termote/main/scripts/get.ps1 | iex
+    ```
+
+    Options: `$env:TERMOTE_UPDATE="true"`, `$env:TERMOTE_AUTO_YES="true"`
+  </TabItem>
+</Tabs>
 
 ### Manual Update
 
-```bash
-./scripts/termote.sh uninstall native
-git pull origin main
-./scripts/termote.sh install native
-```
+<Tabs>
+  <TabItem label="Unix (macOS/Linux)">
+    ```bash
+    ./scripts/termote.sh uninstall native
+    git pull origin main
+    ./scripts/termote.sh install native
+    ```
+  </TabItem>
+  <TabItem label="Windows (PowerShell)">
+    ```powershell
+    .\scripts\termote.ps1 uninstall native
+    git pull origin main
+    .\scripts\termote.ps1 install native
+    ```
+  </TabItem>
+</Tabs>
 
 ## Uninstall
 
-```bash
-./scripts/termote.sh uninstall native
-```
+<Tabs>
+  <TabItem label="Unix (macOS/Linux)">
+    ```bash
+    ./scripts/termote.sh uninstall native
+    ```
+  </TabItem>
+  <TabItem label="Windows (PowerShell)">
+    ```powershell
+    .\scripts\termote.ps1 uninstall native
+    ```
+  </TabItem>
+</Tabs>

--- a/website/src/content/docs/installation/tailscale.mdx
+++ b/website/src/content/docs/installation/tailscale.mdx
@@ -3,7 +3,7 @@ title: Tailscale HTTPS
 description: Auto SSL via tailscale serve
 ---
 
-import { Aside, Steps } from "@astrojs/starlight/components";
+import { Aside, Steps, Tabs, TabItem } from "@astrojs/starlight/components";
 
 Automatic HTTPS using `tailscale serve`. No manual certificate management.
 
@@ -16,9 +16,19 @@ Automatic HTTPS using `tailscale serve`. No manual certificate management.
 
 <Steps>
 1. Deploy with Tailscale flag
-   ```bash
-   ./scripts/termote.sh install container --tailscale myhost.ts.net
-   ```
+
+   <Tabs>
+     <TabItem label="Unix (macOS/Linux)">
+       ```bash
+       ./scripts/termote.sh install container --tailscale myhost.ts.net
+       ```
+     </TabItem>
+     <TabItem label="Windows (PowerShell)">
+       ```powershell
+       .\scripts\termote.ps1 install container -Tailscale myhost.ts.net
+       ```
+     </TabItem>
+   </Tabs>
 
 2. Access at https://myhost.ts.net
 
@@ -26,13 +36,26 @@ Automatic HTTPS using `tailscale serve`. No manual certificate management.
 
 ## Options
 
-```bash
-# Custom port
-./scripts/termote.sh install native --tailscale myhost.ts.net:8765
+<Tabs>
+  <TabItem label="Unix (macOS/Linux)">
+    ```bash
+    # Custom port
+    ./scripts/termote.sh install native --tailscale myhost.ts.net:8765
 
-# Tailscale + LAN
-./scripts/termote.sh install container --tailscale myhost.ts.net --lan
-```
+    # Tailscale + LAN
+    ./scripts/termote.sh install container --tailscale myhost.ts.net --lan
+    ```
+  </TabItem>
+  <TabItem label="Windows (PowerShell)">
+    ```powershell
+    # Custom port
+    .\scripts\termote.ps1 install native -Tailscale myhost.ts.net:8765
+
+    # Tailscale + LAN
+    .\scripts\termote.ps1 install container -Tailscale myhost.ts.net -Lan
+    ```
+  </TabItem>
+</Tabs>
 
 <Aside type="tip">
   Tailscale is the recommended way to expose Termote securely over the internet.

--- a/website/src/content/docs/vi/installation/docker.mdx
+++ b/website/src/content/docs/vi/installation/docker.mdx
@@ -3,7 +3,7 @@ title: Cài đặt Container
 description: Triển khai container tất-cả-trong-một
 ---
 
-import { Aside, Steps } from "@astrojs/starlight/components";
+import { Aside, Steps, Tabs, TabItem } from "@astrojs/starlight/components";
 
 Container đơn với tmux-api (PWA + proxy) + ttyd + tmux.
 
@@ -11,16 +11,36 @@ Container đơn với tmux-api (PWA + proxy) + ttyd + tmux.
 
 <Steps>
 1. Chạy lệnh deploy
-   ```bash
-   ./scripts/termote.sh install container
-   ```
+
+   <Tabs>
+     <TabItem label="Unix (macOS/Linux)">
+       ```bash
+       ./scripts/termote.sh install container
+       ```
+     </TabItem>
+     <TabItem label="Windows (PowerShell)">
+       ```powershell
+       .\scripts\termote.ps1 install container
+       ```
+     </TabItem>
+   </Tabs>
 
 2. Truy cập tại http://localhost:7680
 
 3. (Tùy chọn) Mở ra LAN
-   ```bash
-   ./scripts/termote.sh install container --lan
-   ```
+
+   <Tabs>
+     <TabItem label="Unix (macOS/Linux)">
+       ```bash
+       ./scripts/termote.sh install container --lan
+       ```
+     </TabItem>
+     <TabItem label="Windows (PowerShell)">
+       ```powershell
+       .\scripts\termote.ps1 install container -Lan
+       ```
+     </TabItem>
+   </Tabs>
 
 </Steps>
 
@@ -48,14 +68,28 @@ docker run -d --name termote -p 7680:7680 \
 
 ## Tùy chọn
 
-| Cờ                | Mô tả                                         |
-| ----------------- | --------------------------------------------- |
-| `--lan`           | Mở ra LAN (mặc định: localhost)               |
-| `--no-auth`       | Tắt xác thực cơ bản                           |
-| `--port <port>`   | Cổng tùy chỉnh (mặc định: 7680)               |
-| `--fresh`         | Buộc nhập mật khẩu mới (bỏ qua config đã lưu) |
-| `--update`        | Cập nhật tự động với config đã lưu            |
-| `--version <ver>` | Cài đặt phiên bản cụ thể                      |
+<Tabs>
+  <TabItem label="Unix (macOS/Linux)">
+    | Cờ                | Mô tả                                         |
+    | ----------------- | --------------------------------------------- |
+    | `--lan`           | Mở ra LAN (mặc định: localhost)               |
+    | `--no-auth`       | Tắt xác thực cơ bản                           |
+    | `--port <port>`   | Cổng tùy chỉnh (mặc định: 7680)               |
+    | `--fresh`         | Buộc nhập mật khẩu mới (bỏ qua config đã lưu) |
+    | `--update`        | Cập nhật tự động với config đã lưu            |
+    | `--version <ver>` | Cài đặt phiên bản cụ thể                      |
+  </TabItem>
+  <TabItem label="Windows (PowerShell)">
+    | Cờ                | Mô tả                                         |
+    | ----------------- | --------------------------------------------- |
+    | `-Lan`            | Mở ra LAN (mặc định: localhost)               |
+    | `-NoAuth`         | Tắt xác thực cơ bản                           |
+    | `-Port <port>`    | Cổng tùy chỉnh (mặc định: 7680)               |
+    | `-Fresh`          | Buộc nhập mật khẩu mới (bỏ qua config đã lưu) |
+
+    Cờ online installer: `$env:TERMOTE_UPDATE="true"` để cập nhật tự động.
+  </TabItem>
+</Tabs>
 
 <Aside type="tip">
   Script tự động phát hiện `podman` hoặc `docker` - cả hai hoạt động giống nhau.
@@ -90,10 +124,20 @@ pkill caffeinate
 
 ### Chẩn đoán nhanh
 
-```bash
-./scripts/termote.sh health   # Kiểm tra sức khỏe
-docker ps -a | grep termote   # Kiểm tra trạng thái container
-```
+<Tabs>
+  <TabItem label="Unix (macOS/Linux)">
+    ```bash
+    ./scripts/termote.sh health   # Kiểm tra sức khỏe
+    docker ps -a | grep termote   # Kiểm tra trạng thái container
+    ```
+  </TabItem>
+  <TabItem label="Windows (PowerShell)">
+    ```powershell
+    .\scripts\termote.ps1 health   # Kiểm tra sức khỏe
+    docker ps -a | Select-String termote   # Kiểm tra trạng thái container
+    ```
+  </TabItem>
+</Tabs>
 
 ### Xem logs
 
@@ -107,16 +151,32 @@ podman logs termote
 
 ### Container không khởi động
 
-```bash
-# Kiểm tra lỗi khởi động
-docker logs termote
+<Tabs>
+  <TabItem label="Unix (macOS/Linux)">
+    ```bash
+    # Kiểm tra lỗi khởi động
+    docker logs termote
 
-# Cổng đang dùng?
-lsof -i :7680
+    # Cổng đang dùng?
+    lsof -i :7680
 
-# Dùng cổng khác
-./scripts/termote.sh install container --port 7690
-```
+    # Dùng cổng khác
+    ./scripts/termote.sh install container --port 7690
+    ```
+  </TabItem>
+  <TabItem label="Windows (PowerShell)">
+    ```powershell
+    # Kiểm tra lỗi khởi động
+    docker logs termote
+
+    # Cổng đang dùng?
+    netstat -ano | Select-String 7680
+
+    # Dùng cổng khác
+    .\scripts\termote.ps1 install container -Port 7690
+    ```
+  </TabItem>
+</Tabs>
 
 ### Debug trong container
 
@@ -140,13 +200,26 @@ curl localhost:7680/api/tmux/health
 
 ### Khởi động lại / Reset
 
-```bash
-docker restart termote
+<Tabs>
+  <TabItem label="Unix (macOS/Linux)">
+    ```bash
+    docker restart termote
 
-# Reset hoàn toàn
-./scripts/termote.sh uninstall container
-./scripts/termote.sh install container
-```
+    # Reset hoàn toàn
+    ./scripts/termote.sh uninstall container
+    ./scripts/termote.sh install container
+    ```
+  </TabItem>
+  <TabItem label="Windows (PowerShell)">
+    ```powershell
+    docker restart termote
+
+    # Reset hoàn toàn
+    .\scripts\termote.ps1 uninstall container
+    .\scripts\termote.ps1 install container
+    ```
+  </TabItem>
+</Tabs>
 
 ### Test API
 
@@ -161,32 +234,61 @@ curl -u admin:password http://localhost:7680/api/tmux/sessions
 
 Chạy lại installer - sẽ so sánh version và hỏi trước khi cập nhật:
 
-```bash
-# Cập nhật tự động với config đã lưu
-curl -fsSL https://raw.githubusercontent.com/lamngockhuong/termote/main/scripts/get.sh | bash -s -- --update
+<Tabs>
+  <TabItem label="Unix (macOS/Linux)">
+    ```bash
+    # Cập nhật tự động với config đã lưu
+    curl -fsSL https://raw.githubusercontent.com/lamngockhuong/termote/main/scripts/get.sh | bash -s -- --update
 
-# Hoặc cập nhật chuẩn
-curl -fsSL https://raw.githubusercontent.com/lamngockhuong/termote/main/scripts/get.sh | bash -s -- --container
-```
+    # Hoặc cập nhật chuẩn
+    curl -fsSL https://raw.githubusercontent.com/lamngockhuong/termote/main/scripts/get.sh | bash -s -- --container
+    ```
 
-Tùy chọn:
+    Tùy chọn: `--update`, `--yes`, `--download-only`, `--fresh`, `--strict`
+  </TabItem>
+  <TabItem label="Windows (PowerShell)">
+    ```powershell
+    # Cập nhật tự động với config đã lưu
+    $env:TERMOTE_UPDATE="true"; irm https://raw.githubusercontent.com/lamngockhuong/termote/main/scripts/get.ps1 | iex
 
-- `--update` - Cập nhật tự động dùng config đã lưu (mode, flags, password)
-- `--yes` - Tự động cập nhật không hỏi
-- `--download-only` - Chỉ tải về, không cài đặt
-- `--fresh` - Buộc nhập mật khẩu mới
-- `--strict` - Yêu cầu xác minh checksum (lỗi nếu không có)
+    # Hoặc cập nhật chuẩn
+    $env:TERMOTE_MODE="container"; irm https://raw.githubusercontent.com/lamngockhuong/termote/main/scripts/get.ps1 | iex
+    ```
+
+    Tùy chọn: `$env:TERMOTE_UPDATE="true"`, `$env:TERMOTE_AUTO_YES="true"`, `$env:TERMOTE_MODE="container"`
+  </TabItem>
+</Tabs>
 
 ### Cập nhật thủ công
 
-```bash
-./scripts/termote.sh uninstall container
-git pull origin main
-./scripts/termote.sh install container
-```
+<Tabs>
+  <TabItem label="Unix (macOS/Linux)">
+    ```bash
+    ./scripts/termote.sh uninstall container
+    git pull origin main
+    ./scripts/termote.sh install container
+    ```
+  </TabItem>
+  <TabItem label="Windows (PowerShell)">
+    ```powershell
+    .\scripts\termote.ps1 uninstall container
+    git pull origin main
+    .\scripts\termote.ps1 install container
+    ```
+  </TabItem>
+</Tabs>
 
 ## Gỡ cài đặt
 
-```bash
-./scripts/termote.sh uninstall container
-```
+<Tabs>
+  <TabItem label="Unix (macOS/Linux)">
+    ```bash
+    ./scripts/termote.sh uninstall container
+    ```
+  </TabItem>
+  <TabItem label="Windows (PowerShell)">
+    ```powershell
+    .\scripts\termote.ps1 uninstall container
+    ```
+  </TabItem>
+</Tabs>

--- a/website/src/content/docs/vi/installation/native.mdx
+++ b/website/src/content/docs/vi/installation/native.mdx
@@ -49,9 +49,18 @@ Không cần Docker. Truy cập binary host như `claude`, `git`, `gh`, v.v.
 
 2. Chạy lệnh deploy
 
-   ```bash
-   ./scripts/termote.sh install native
-   ```
+   <Tabs>
+     <TabItem label="Unix (macOS/Linux)">
+       ```bash
+       ./scripts/termote.sh install native
+       ```
+     </TabItem>
+     <TabItem label="Windows (PowerShell)">
+       ```powershell
+       .\scripts\termote.ps1 install native
+       ```
+     </TabItem>
+   </Tabs>
 
 3. Truy cập tại http://localhost:7680
 
@@ -70,14 +79,27 @@ Không cần Docker. Truy cập binary host như `claude`, `git`, `gh`, v.v.
 
 ## Quản lý dịch vụ
 
-```bash
-# Kiểm tra processes
-ps aux | grep ttyd
-ps aux | grep tmux-api
+<Tabs>
+  <TabItem label="Unix (macOS/Linux)">
+    ```bash
+    # Kiểm tra processes
+    ps aux | grep ttyd
+    ps aux | grep tmux-api
 
-# Khởi động lại
-./scripts/termote.sh install native
-```
+    # Khởi động lại
+    ./scripts/termote.sh install native
+    ```
+  </TabItem>
+  <TabItem label="Windows (PowerShell)">
+    ```powershell
+    # Kiểm tra processes
+    Get-Process -Name ttyd, tmux-api -ErrorAction SilentlyContinue
+
+    # Khởi động lại
+    .\scripts\termote.ps1 install native
+    ```
+  </TabItem>
+</Tabs>
 
 ## Ngăn macOS Sleep
 
@@ -103,54 +125,106 @@ pkill caffeinate
 
 ### Chẩn đoán nhanh
 
-```bash
-./scripts/termote.sh health   # Kiểm tra sức khỏe
-ss -tlnp | grep -E "7680|7681"  # Kiểm tra cổng
-```
+<Tabs>
+  <TabItem label="Unix (macOS/Linux)">
+    ```bash
+    ./scripts/termote.sh health   # Kiểm tra sức khỏe
+    ss -tlnp | grep -E "7680|7681"  # Kiểm tra cổng
+    ```
+  </TabItem>
+  <TabItem label="Windows (PowerShell)">
+    ```powershell
+    .\scripts\termote.ps1 health   # Kiểm tra sức khỏe
+    netstat -ano | Select-String "7680|7681"  # Kiểm tra cổng
+    ```
+  </TabItem>
+</Tabs>
 
 ### Kiểm tra tiến trình
 
-```bash
-ps aux | grep ttyd         # Kiểm tra ttyd đang chạy
-ps aux | grep tmux-api     # Kiểm tra tmux-api đang chạy
-lsof -i :7680              # Xác minh cổng chính
-lsof -i :7681              # Xác minh cổng ttyd
-```
+<Tabs>
+  <TabItem label="Unix (macOS/Linux)">
+    ```bash
+    ps aux | grep ttyd         # Kiểm tra ttyd đang chạy
+    ps aux | grep tmux-api     # Kiểm tra tmux-api đang chạy
+    lsof -i :7680              # Xác minh cổng chính
+    lsof -i :7681              # Xác minh cổng ttyd
+    ```
+  </TabItem>
+  <TabItem label="Windows (PowerShell)">
+    ```powershell
+    Get-Process -Name ttyd, tmux-api -ErrorAction SilentlyContinue
+    netstat -ano | Select-String "7680"   # Xác minh cổng chính
+    netstat -ano | Select-String "7681"   # Xác minh cổng ttyd
+    ```
+  </TabItem>
+</Tabs>
 
 ### Debug với logs
 
-Chế độ native mặc định không ghi logs. Để xem logs:
+<Tabs>
+  <TabItem label="Unix (macOS/Linux)">
+    Chế độ native mặc định không ghi logs. Để xem logs:
 
-```bash
-# Dừng dịch vụ
-./scripts/termote.sh uninstall native
+    ```bash
+    # Dừng dịch vụ
+    ./scripts/termote.sh uninstall native
 
-# Chạy ttyd với logs (terminal 1)
-ttyd -W -i lo -p 7681 tmux new-session -A -s main
+    # Chạy ttyd với logs (terminal 1)
+    ttyd -W -i lo -p 7681 tmux new-session -A -s main
 
-# Chạy tmux-api với logs (terminal 2)
-cd tmux-api
-TERMOTE_PORT=7680 TERMOTE_BIND=127.0.0.1 \
-TERMOTE_PWA_DIR=../pwa/dist ./tmux-api-native
-```
+    # Chạy tmux-api với logs (terminal 2)
+    cd tmux-api
+    TERMOTE_PORT=7680 TERMOTE_BIND=127.0.0.1 \
+    TERMOTE_PWA_DIR=../pwa/dist ./tmux-api-native
+    ```
+  </TabItem>
+  <TabItem label="Windows (PowerShell)">
+    Chế độ native mặc định không ghi logs. Để xem logs:
+
+    ```powershell
+    # Dừng dịch vụ
+    .\scripts\termote.ps1 uninstall native
+
+    # Chạy ttyd với logs (terminal 1)
+    ttyd -W -i 127.0.0.1 -p 7681 psmux
+
+    # Chạy tmux-api với logs (terminal 2)
+    cd tmux-api
+    $env:TERMOTE_PORT=7680; $env:TERMOTE_BIND="127.0.0.1"
+    $env:TERMOTE_PWA_DIR="../pwa/dist"; .\tmux-api.exe
+    ```
+  </TabItem>
+</Tabs>
 
 ### Lỗi thường gặp
 
 | Lỗi            | Giải pháp                                           |
 | -------------- | --------------------------------------------------- |
-| Cổng đang dùng | `lsof -i :7680` rồi kill process                    |
-| Thiếu ttyd     | `brew install ttyd` (macOS) hoặc `apt install ttyd` |
+| Cổng đang dùng | `lsof -i :7680` (Unix) hoặc `netstat -ano \| Select-String 7680` (Win) rồi kill process |
+| Thiếu ttyd     | `brew install ttyd` (macOS) hoặc `apt install ttyd` (Linux) |
 | Thiếu binary   | `cd tmux-api && go build -o tmux-api-native .`      |
 | PWA chưa build | `cd pwa && pnpm build`                              |
 | PWA cache cũ   | Settings → "Clear Cache & Reload" để làm mới        |
 
-### tmux Session
+### tmux / psmux Session
 
-```bash
-tmux list-sessions         # Liệt kê sessions
-tmux attach -t main        # Kết nối vào session
-tmux kill-session -t main  # Reset session
-```
+<Tabs>
+  <TabItem label="Unix (macOS/Linux)">
+    ```bash
+    tmux list-sessions         # Liệt kê sessions
+    tmux attach -t main        # Kết nối vào session
+    tmux kill-session -t main  # Reset session
+    ```
+  </TabItem>
+  <TabItem label="Windows (PowerShell)">
+    ```powershell
+    psmux list-sessions         # Liệt kê sessions
+    psmux attach -t main        # Kết nối vào session
+    psmux kill-session -t main  # Reset session
+    ```
+  </TabItem>
+</Tabs>
 
 ### Test API
 
@@ -165,33 +239,61 @@ curl http://localhost:7680/api/tmux/sessions
 
 Chạy lại installer - sẽ so sánh version và hỏi trước khi cập nhật:
 
-```bash
-# Cập nhật tự động với config đã lưu
-curl -fsSL https://raw.githubusercontent.com/lamngockhuong/termote/main/scripts/get.sh | bash -s -- --update
+<Tabs>
+  <TabItem label="Unix (macOS/Linux)">
+    ```bash
+    # Cập nhật tự động với config đã lưu
+    curl -fsSL https://raw.githubusercontent.com/lamngockhuong/termote/main/scripts/get.sh | bash -s -- --update
 
-# Hoặc cập nhật chuẩn
-curl -fsSL https://raw.githubusercontent.com/lamngockhuong/termote/main/scripts/get.sh | bash
-```
+    # Hoặc cập nhật chuẩn
+    curl -fsSL https://raw.githubusercontent.com/lamngockhuong/termote/main/scripts/get.sh | bash
+    ```
 
-Tùy chọn:
+    Tùy chọn: `--update`, `--yes`, `--download-only`, `--fresh`, `--version <ver>`, `--strict`
+  </TabItem>
+  <TabItem label="Windows (PowerShell)">
+    ```powershell
+    # Cập nhật tự động với config đã lưu
+    $env:TERMOTE_UPDATE="true"; irm https://raw.githubusercontent.com/lamngockhuong/termote/main/scripts/get.ps1 | iex
 
-- `--update` - Cập nhật tự động dùng config đã lưu (mode, flags, password)
-- `--yes` - Tự động cập nhật không hỏi
-- `--download-only` - Chỉ tải về, không cài đặt
-- `--fresh` - Buộc nhập mật khẩu mới
-- `--version <ver>` - Cài đặt phiên bản cụ thể
-- `--strict` - Yêu cầu xác minh checksum (lỗi nếu không có)
+    # Hoặc cập nhật chuẩn
+    irm https://raw.githubusercontent.com/lamngockhuong/termote/main/scripts/get.ps1 | iex
+    ```
+
+    Tùy chọn: `$env:TERMOTE_UPDATE="true"`, `$env:TERMOTE_AUTO_YES="true"`
+  </TabItem>
+</Tabs>
 
 ### Cập nhật thủ công
 
-```bash
-./scripts/termote.sh uninstall native
-git pull origin main
-./scripts/termote.sh install native
-```
+<Tabs>
+  <TabItem label="Unix (macOS/Linux)">
+    ```bash
+    ./scripts/termote.sh uninstall native
+    git pull origin main
+    ./scripts/termote.sh install native
+    ```
+  </TabItem>
+  <TabItem label="Windows (PowerShell)">
+    ```powershell
+    .\scripts\termote.ps1 uninstall native
+    git pull origin main
+    .\scripts\termote.ps1 install native
+    ```
+  </TabItem>
+</Tabs>
 
 ## Gỡ cài đặt
 
-```bash
-./scripts/termote.sh uninstall native
-```
+<Tabs>
+  <TabItem label="Unix (macOS/Linux)">
+    ```bash
+    ./scripts/termote.sh uninstall native
+    ```
+  </TabItem>
+  <TabItem label="Windows (PowerShell)">
+    ```powershell
+    .\scripts\termote.ps1 uninstall native
+    ```
+  </TabItem>
+</Tabs>

--- a/website/src/content/docs/vi/installation/tailscale.mdx
+++ b/website/src/content/docs/vi/installation/tailscale.mdx
@@ -3,7 +3,7 @@ title: Tailscale HTTPS
 description: Tự động SSL qua tailscale serve
 ---
 
-import { Aside, Steps } from "@astrojs/starlight/components";
+import { Aside, Steps, Tabs, TabItem } from "@astrojs/starlight/components";
 
 Tự động HTTPS sử dụng `tailscale serve`. Không cần quản lý chứng chỉ thủ công.
 
@@ -16,9 +16,19 @@ Tự động HTTPS sử dụng `tailscale serve`. Không cần quản lý chứn
 
 <Steps>
 1. Triển khai với cờ Tailscale
-   ```bash
-   ./scripts/termote.sh install container --tailscale myhost.ts.net
-   ```
+
+   <Tabs>
+     <TabItem label="Unix (macOS/Linux)">
+       ```bash
+       ./scripts/termote.sh install container --tailscale myhost.ts.net
+       ```
+     </TabItem>
+     <TabItem label="Windows (PowerShell)">
+       ```powershell
+       .\scripts\termote.ps1 install container -Tailscale myhost.ts.net
+       ```
+     </TabItem>
+   </Tabs>
 
 2. Truy cập tại https://myhost.ts.net
 
@@ -26,13 +36,26 @@ Tự động HTTPS sử dụng `tailscale serve`. Không cần quản lý chứn
 
 ## Tùy chọn
 
-```bash
-# Cổng tùy chỉnh
-./scripts/termote.sh install native --tailscale myhost.ts.net:8765
+<Tabs>
+  <TabItem label="Unix (macOS/Linux)">
+    ```bash
+    # Cổng tùy chỉnh
+    ./scripts/termote.sh install native --tailscale myhost.ts.net:8765
 
-# Tailscale + LAN
-./scripts/termote.sh install container --tailscale myhost.ts.net --lan
-```
+    # Tailscale + LAN
+    ./scripts/termote.sh install container --tailscale myhost.ts.net --lan
+    ```
+  </TabItem>
+  <TabItem label="Windows (PowerShell)">
+    ```powershell
+    # Cổng tùy chỉnh
+    .\scripts\termote.ps1 install native -Tailscale myhost.ts.net:8765
+
+    # Tailscale + LAN
+    .\scripts\termote.ps1 install container -Tailscale myhost.ts.net -Lan
+    ```
+  </TabItem>
+</Tabs>
 
 <Aside type="tip">
   Tailscale là cách được khuyến nghị để expose Termote an toàn qua internet.


### PR DESCRIPTION
## Summary

- Added Windows PowerShell tabs (`termote.ps1`) alongside Unix bash commands in all installation docs
- Updated 6 files: `docker.mdx`, `native.mdx`, `tailscale.mdx` (EN + VI)
- Covers: quick start, options, troubleshooting, service management, updating, and uninstall sections

## Test plan

- [x] `npx astro build` passes with no errors
- [ ] Verify tabs render correctly on docs site
- [ ] Verify PowerShell commands match `termote.ps1` flags (`-Lan`, `-NoAuth`, `-Fresh`, `-Tailscale`, `-Port`)