### PR TITLE
fix(auth): add session cookie to prevent double basic auth on mobile

### DIFF
--- a/tmux-api/serve.go
+++ b/tmux-api/serve.go
@@ -49,19 +49,25 @@ func envOr(key, fallback string) string {
 	return fallback
 }
 
-// terminalTokenStore manages single-use, time-limited tokens for terminal iframe access.
-type terminalTokenStore struct {
-	mu     sync.Mutex
-	tokens map[string]time.Time // token → expiry
+// tokenStore manages time-limited tokens with configurable behavior.
+type tokenStore struct {
+	mu        sync.RWMutex
+	tokens    map[string]time.Time // token → expiry
+	ttl       time.Duration
+	singleUse bool
 }
 
-func newTerminalTokenStore() *terminalTokenStore {
-	return &terminalTokenStore{tokens: make(map[string]time.Time)}
+func newTokenStore(ttl time.Duration, singleUse bool) *tokenStore {
+	return &tokenStore{
+		tokens:    make(map[string]time.Time),
+		ttl:       ttl,
+		singleUse: singleUse,
+	}
 }
 
-// generate creates a single-use token valid for 30 seconds.
-// Also sweeps expired tokens to prevent unbounded map growth.
-func (s *terminalTokenStore) generate() (string, error) {
+// generate creates a token valid for the configured TTL.
+// Sweeps expired tokens to prevent unbounded map growth.
+func (s *tokenStore) generate() (string, error) {
 	b := make([]byte, 16)
 	if _, err := rand.Read(b); err != nil {
 		return "", err
@@ -69,28 +75,45 @@ func (s *terminalTokenStore) generate() (string, error) {
 	token := hex.EncodeToString(b)
 	now := time.Now()
 	s.mu.Lock()
-	// Sweep expired tokens
 	for k, exp := range s.tokens {
 		if now.After(exp) {
 			delete(s.tokens, k)
 		}
 	}
-	s.tokens[token] = now.Add(30 * time.Second)
+	s.tokens[token] = now.Add(s.ttl)
 	s.mu.Unlock()
 	return token, nil
 }
 
-// validate checks and consumes a token (single-use).
-func (s *terminalTokenStore) validate(token string) bool {
+// validate checks a token. If singleUse is true, consumes the token.
+func (s *tokenStore) validate(token string) bool {
+	now := time.Now()
+	// Fast path: read-only check for reusable tokens
+	if !s.singleUse {
+		s.mu.RLock()
+		expiry, ok := s.tokens[token]
+		s.mu.RUnlock()
+		if !ok || now.After(expiry) {
+			return false
+		}
+		return true
+	}
+	// Single-use: need write lock to delete
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	expiry, ok := s.tokens[token]
-	if !ok || time.Now().After(expiry) {
-		delete(s.tokens, token)
+	if !ok || now.After(expiry) {
 		return false
 	}
-	delete(s.tokens, token) // single-use: consume immediately
+	delete(s.tokens, token)
 	return true
+}
+
+// Legacy aliases for terminal tokens (30s, single-use)
+type terminalTokenStore = tokenStore
+
+func newTerminalTokenStore() *terminalTokenStore {
+	return newTokenStore(30*time.Second, true)
 }
 
 // startServeMode starts the server (PWA static files + ttyd WebSocket proxy + tmux API + basic auth)
@@ -219,17 +242,35 @@ func isPWAPublicPath(path string) bool {
 	return false
 }
 
+const (
+	sessionCookieName = "termote_session"
+	sessionTTL        = 24 * time.Hour
+)
+
 // basicAuth wraps a handler with HTTP basic authentication.
+// After successful basic auth, sets a session cookie to avoid re-prompting
+// (fixes mobile browsers not persisting basic auth across iframe loads).
 // Note: uses r.RemoteAddr for rate limiting. Behind a reverse proxy, all clients
 // may share one IP — consider the proxy's own rate limiting in that setup.
 func basicAuth(user, pass string, next http.Handler) http.Handler {
 	limiter := newAuthRateLimiter()
+	sessions := newTokenStore(sessionTTL, false)
+
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Skip auth for PWA public paths (manifest, service worker)
 		if isPWAPublicPath(r.URL.Path) {
 			next.ServeHTTP(w, r)
 			return
 		}
+
+		// Check session cookie first (fixes mobile iframe auth issue)
+		if cookie, err := r.Cookie(sessionCookieName); err == nil {
+			if sessions.validate(cookie.Value) {
+				next.ServeHTTP(w, r)
+				return
+			}
+		}
+
 		// Extract client IP (strip port)
 		ip, _, _ := net.SplitHostPort(r.RemoteAddr)
 		if ip == "" {
@@ -254,6 +295,23 @@ func basicAuth(user, pass string, next http.Handler) http.Handler {
 			http.Error(w, "Unauthorized", http.StatusUnauthorized)
 			return
 		}
+
+		// Set session cookie to avoid re-prompting on mobile iframe loads
+		sessionToken, err := sessions.generate()
+		if err != nil {
+			log.Printf("session token generation failed: %v", err)
+		} else {
+			http.SetCookie(w, &http.Cookie{
+				Name:     sessionCookieName,
+				Value:    sessionToken,
+				Path:     "/",
+				MaxAge:   int(sessionTTL.Seconds()),
+				HttpOnly: true,
+				SameSite: http.SameSiteStrictMode,
+				Secure:   r.TLS != nil || r.Header.Get("X-Forwarded-Proto") == "https",
+			})
+		}
+
 		next.ServeHTTP(w, r)
 	})
 }

--- a/tmux-api/serve_test.go
+++ b/tmux-api/serve_test.go
@@ -564,3 +564,131 @@ func TestNewWebSocketProxyDetection(t *testing.T) {
 		t.Error("proxy should return a response")
 	}
 }
+
+func TestTokenStoreReusable(t *testing.T) {
+	store := newTokenStore(time.Hour, false) // reusable tokens
+
+	t.Run("generate and validate", func(t *testing.T) {
+		token, err := store.generate()
+		if err != nil {
+			t.Fatalf("generate failed: %v", err)
+		}
+		if !store.validate(token) {
+			t.Error("valid token should pass validation")
+		}
+	})
+
+	t.Run("reusable token validates multiple times", func(t *testing.T) {
+		token, _ := store.generate()
+		for i := 0; i < 5; i++ {
+			if !store.validate(token) {
+				t.Errorf("reusable token should validate on attempt %d", i+1)
+			}
+		}
+	})
+
+	t.Run("invalid token rejected", func(t *testing.T) {
+		if store.validate("nonexistent") {
+			t.Error("invalid token should fail validation")
+		}
+	})
+
+	t.Run("expired token rejected", func(t *testing.T) {
+		shortStore := newTokenStore(time.Millisecond, false)
+		token, _ := shortStore.generate()
+		time.Sleep(5 * time.Millisecond)
+		if shortStore.validate(token) {
+			t.Error("expired token should fail validation")
+		}
+	})
+}
+
+func TestBasicAuthSessionCookie(t *testing.T) {
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	handler := basicAuth("admin", "secret", inner)
+
+	t.Run("sets session cookie on successful auth", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/api/test", nil)
+		req.SetBasicAuth("admin", "secret")
+		rec := httptest.NewRecorder()
+
+		handler.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d", rec.Code)
+		}
+
+		cookies := rec.Result().Cookies()
+		var sessionCookie *http.Cookie
+		for _, c := range cookies {
+			if c.Name == sessionCookieName {
+				sessionCookie = c
+				break
+			}
+		}
+		if sessionCookie == nil {
+			t.Fatal("session cookie not set")
+		}
+		if !sessionCookie.HttpOnly {
+			t.Error("session cookie should be HttpOnly")
+		}
+		if sessionCookie.SameSite != http.SameSiteStrictMode {
+			t.Error("session cookie should have SameSite=Strict")
+		}
+	})
+
+	t.Run("session cookie allows access without basic auth", func(t *testing.T) {
+		// First request: authenticate and get cookie
+		req1 := httptest.NewRequest("GET", "/api/test", nil)
+		req1.SetBasicAuth("admin", "secret")
+		rec1 := httptest.NewRecorder()
+		handler.ServeHTTP(rec1, req1)
+
+		cookies := rec1.Result().Cookies()
+		var sessionCookie *http.Cookie
+		for _, c := range cookies {
+			if c.Name == sessionCookieName {
+				sessionCookie = c
+				break
+			}
+		}
+		if sessionCookie == nil {
+			t.Fatal("session cookie not set")
+		}
+
+		// Second request: use cookie, no basic auth
+		req2 := httptest.NewRequest("GET", "/api/test", nil)
+		req2.AddCookie(sessionCookie)
+		rec2 := httptest.NewRecorder()
+		handler.ServeHTTP(rec2, req2)
+
+		if rec2.Code != http.StatusOK {
+			t.Errorf("session cookie should grant access, got %d", rec2.Code)
+		}
+	})
+
+	t.Run("invalid session cookie falls back to basic auth", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/api/test", nil)
+		req.AddCookie(&http.Cookie{Name: sessionCookieName, Value: "invalid"})
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusUnauthorized {
+			t.Errorf("invalid cookie without basic auth should return 401, got %d", rec.Code)
+		}
+	})
+
+	t.Run("invalid cookie with valid basic auth succeeds", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/api/test", nil)
+		req.AddCookie(&http.Cookie{Name: sessionCookieName, Value: "invalid"})
+		req.SetBasicAuth("admin", "secret")
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusOK {
+			t.Errorf("valid basic auth should succeed even with invalid cookie, got %d", rec.Code)
+		}
+	})
+}


### PR DESCRIPTION
## Summary
- Fix mobile browsers requiring basic auth twice (once for PWA, once for terminal iframe)
- Add session cookie (24h TTL) after successful basic auth
- Refactor `tokenStore` to support both single-use and reusable tokens
- Use `RWMutex` for better read-heavy session validation performance

## Root Cause
Mobile browsers don't persist basic auth credentials across iframe loads (different browsing context).

## Solution
1. On successful basic auth, set `termote_session` cookie (HttpOnly, SameSite=Strict)
2. Subsequent requests check cookie first, skip basic auth prompt
3. Terminal iframe loads now use the session cookie automatically

## Test Plan
- [x] Unit tests for session cookie behavior (4 test cases)
- [x] Unit tests for reusable token store (4 test cases)
- [x] All existing tests pass
- [ ] Manual test on iOS Safari
- [ ] Manual test on Android Chrome