### PR TITLE
feat(pwa): add context menu disable setting with toggle in preferences

### DIFF
--- a/.claude/.gitignore
+++ b/.claude/.gitignore
@@ -1,0 +1,1 @@
+session-state/

--- a/pwa/e2e/ui-features.spec.ts
+++ b/pwa/e2e/ui-features.spec.ts
@@ -288,8 +288,8 @@ test.describe('preferences modal', () => {
     await page.click('text=Preferences')
     await page.waitForTimeout(200)
 
-    // Click toggle switch
-    const toggle = page.locator('button[role="switch"]')
+    // Click the first toggle switch (toolbar default expanded)
+    const toggle = page.locator('button[role="switch"]').first()
     await expect(toggle).toHaveAttribute('aria-checked', 'false')
     await toggle.click()
     await page.waitForTimeout(100)
@@ -298,6 +298,45 @@ test.describe('preferences modal', () => {
     // Verify persisted
     const stored = await page.evaluate(() => localStorage.getItem('termote-settings'))
     expect(JSON.parse(stored!).toolbarDefaultExpanded).toBe(true)
+  })
+
+  test('toggles disable context menu', async ({ page }) => {
+    await page.click('button[aria-label="Settings"]')
+    await page.click('text=Preferences')
+    await page.waitForTimeout(200)
+
+    // Second toggle is "Disable right-click menu" (default: true)
+    const toggle = page.locator('button[role="switch"]').nth(1)
+    await expect(toggle).toHaveAttribute('aria-checked', 'true')
+    await toggle.click()
+    await page.waitForTimeout(100)
+    await expect(toggle).toHaveAttribute('aria-checked', 'false')
+
+    // Verify persisted
+    const stored = await page.evaluate(() => localStorage.getItem('termote-settings'))
+    expect(JSON.parse(stored!).disableContextMenu).toBe(false)
+  })
+
+  test('disable context menu setting persists after reload', async ({ page }) => {
+    // Disable context menu blocking
+    await page.click('button[aria-label="Settings"]')
+    await page.click('text=Preferences')
+    await page.waitForTimeout(200)
+    const toggle = page.locator('button[role="switch"]').nth(1)
+    await toggle.click()
+    await page.waitForTimeout(100)
+
+    // Reload
+    await page.keyboard.press('Escape')
+    await page.reload()
+    await page.waitForSelector('iframe[title="Terminal"]', { timeout: 10000 })
+
+    // Reopen and verify
+    await page.click('button[aria-label="Settings"]')
+    await page.click('text=Preferences')
+    await page.waitForTimeout(200)
+    const toggleAfter = page.locator('button[role="switch"]').nth(1)
+    await expect(toggleAfter).toHaveAttribute('aria-checked', 'false')
   })
 
   test('preferences persist after page reload', async ({ page }) => {

--- a/pwa/src/App.tsx
+++ b/pwa/src/App.tsx
@@ -313,6 +313,7 @@ export default function App() {
           <div
             ref={terminalContainerRef}
             className="flex-1 relative min-h-0 overflow-y-auto scroll-smooth"
+            onContextMenu={(e) => e.preventDefault()}
             style={{
               height:
                 keyboardHeight > 0
@@ -330,6 +331,7 @@ export default function App() {
                 ref={terminalRef}
                 fontSize={fontSize}
                 theme={resolvedTheme}
+                disableContextMenu={settings.disableContextMenu}
               />
             </div>
             {/* Gesture overlay - captures touch gestures (mobile only) */}

--- a/pwa/src/components/settings-modal.tsx
+++ b/pwa/src/components/settings-modal.tsx
@@ -11,6 +11,45 @@ interface Props {
   ) => void
 }
 
+function ToggleRow({
+  label,
+  description,
+  checked,
+  onChange,
+}: {
+  label: string
+  description: string
+  checked: boolean
+  onChange: () => void
+}) {
+  return (
+    <div className="flex items-center justify-between">
+      <div>
+        <p className="block text-sm font-medium text-zinc-700 dark:text-zinc-300">
+          {label}
+        </p>
+        <p className="text-xs text-zinc-500 dark:text-zinc-400 mt-0.5">
+          {description}
+        </p>
+      </div>
+      <button
+        role="switch"
+        aria-checked={checked}
+        onClick={onChange}
+        className={`relative w-11 h-6 rounded-full transition-colors ${
+          checked ? 'bg-blue-500' : 'bg-zinc-300 dark:bg-zinc-600'
+        }`}
+      >
+        <span
+          className={`absolute top-0.5 left-0.5 w-5 h-5 bg-white rounded-full shadow transition-transform ${
+            checked ? 'translate-x-5' : ''
+          }`}
+        />
+      </button>
+    </div>
+  )
+}
+
 const IME_SEND_OPTIONS: {
   value: ImeSendBehavior
   label: string
@@ -112,39 +151,29 @@ export function SettingsModal({
             </div>
           </div>
 
-          <div>
-            <div className="flex items-center justify-between">
-              <div>
-                <p className="block text-sm font-medium text-zinc-700 dark:text-zinc-300">
-                  Toolbar default expanded
-                </p>
-                <p className="text-xs text-zinc-500 dark:text-zinc-400 mt-0.5">
-                  Show all keys when toolbar loads
-                </p>
-              </div>
-              <button
-                role="switch"
-                aria-checked={settings.toolbarDefaultExpanded}
-                onClick={() =>
-                  onUpdateSetting(
-                    'toolbarDefaultExpanded',
-                    !settings.toolbarDefaultExpanded,
-                  )
-                }
-                className={`relative w-11 h-6 rounded-full transition-colors ${
-                  settings.toolbarDefaultExpanded
-                    ? 'bg-blue-500'
-                    : 'bg-zinc-300 dark:bg-zinc-600'
-                }`}
-              >
-                <span
-                  className={`absolute top-0.5 left-0.5 w-5 h-5 bg-white rounded-full shadow transition-transform ${
-                    settings.toolbarDefaultExpanded ? 'translate-x-5' : ''
-                  }`}
-                />
-              </button>
-            </div>
-          </div>
+          <ToggleRow
+            label="Toolbar default expanded"
+            description="Show all keys when toolbar loads"
+            checked={settings.toolbarDefaultExpanded}
+            onChange={() =>
+              onUpdateSetting(
+                'toolbarDefaultExpanded',
+                !settings.toolbarDefaultExpanded,
+              )
+            }
+          />
+
+          <ToggleRow
+            label="Disable right-click menu"
+            description="Block context menu on terminal area"
+            checked={settings.disableContextMenu}
+            onChange={() =>
+              onUpdateSetting(
+                'disableContextMenu',
+                !settings.disableContextMenu,
+              )
+            }
+          />
         </div>
       </div>
     </dialog>

--- a/pwa/src/components/terminal-frame.tsx
+++ b/pwa/src/components/terminal-frame.tsx
@@ -8,9 +8,11 @@ import {
 } from 'react'
 import { fetchTerminalToken } from '../hooks/use-tmux-api'
 import {
+  blockContextMenu,
   sendKeyToTerminal,
   setTerminalFontSize,
   setTerminalTheme,
+  unblockContextMenu,
 } from '../utils/terminal-bridge'
 
 export interface TerminalFrameHandle {
@@ -21,6 +23,7 @@ export interface TerminalFrameHandle {
 interface Props {
   fontSize?: number
   theme?: 'light' | 'dark'
+  disableContextMenu?: boolean
 }
 
 const THEMES = {
@@ -75,7 +78,7 @@ const THEMES = {
 }
 
 export const TerminalFrame = forwardRef<TerminalFrameHandle, Props>(
-  ({ fontSize = 14, theme = 'dark' }, ref) => {
+  ({ fontSize = 14, theme = 'dark', disableContextMenu = true }, ref) => {
     const iframeRef = useRef<HTMLIFrameElement>(null)
     const [terminalSrc, setTerminalSrc] = useState<string | null>(null)
     const [tokenError, setTokenError] = useState<string | null>(null)
@@ -117,9 +120,15 @@ export const TerminalFrame = forwardRef<TerminalFrameHandle, Props>(
       const iframe = iframeRef.current
       if (!iframe) return
 
+      const applyContextMenu = () =>
+        disableContextMenu
+          ? blockContextMenu(iframe)
+          : unblockContextMenu(iframe)
+
       const immediateApplied = setTerminalTheme(iframe, THEMES[theme])
       if (immediateApplied) {
         setTerminalFontSize(iframe, fontSize)
+        applyContextMenu()
         return
       }
 
@@ -131,6 +140,7 @@ export const TerminalFrame = forwardRef<TerminalFrameHandle, Props>(
         const themeApplied = setTerminalTheme(iframe, THEMES[theme])
         if (themeApplied) {
           setTerminalFontSize(iframe, fontSize)
+          applyContextMenu()
           // Clear DA response artifacts leaked by xterm.js on ttyd+tmux connect
           setTimeout(() => sendKeyToTerminal(iframe, 'u', { ctrl: true }), 300)
           if (intervalId) clearInterval(intervalId)
@@ -149,7 +159,7 @@ export const TerminalFrame = forwardRef<TerminalFrameHandle, Props>(
         if (intervalId) clearInterval(intervalId)
         iframe.removeEventListener('load', handleLoad)
       }
-    }, [theme, fontSize, terminalSrc])
+    }, [theme, fontSize, terminalSrc, disableContextMenu])
 
     if (tokenError) {
       return (

--- a/pwa/src/hooks/use-settings.test.ts
+++ b/pwa/src/hooks/use-settings.test.ts
@@ -11,6 +11,7 @@ describe('useSettings', () => {
     const { result } = renderHook(() => useSettings())
     expect(result.current.settings.imeSendBehavior).toBe('send-only')
     expect(result.current.settings.toolbarDefaultExpanded).toBe(false)
+    expect(result.current.settings.disableContextMenu).toBe(true)
   })
 
   it('restores saved settings from localStorage', () => {
@@ -34,6 +35,7 @@ describe('useSettings', () => {
     const { result } = renderHook(() => useSettings())
     expect(result.current.settings.imeSendBehavior).toBe('send-enter')
     expect(result.current.settings.toolbarDefaultExpanded).toBe(false)
+    expect(result.current.settings.disableContextMenu).toBe(true)
   })
 
   it('handles corrupt localStorage gracefully', () => {
@@ -61,5 +63,24 @@ describe('useSettings', () => {
     act(() => a.current.updateSetting('toolbarDefaultExpanded', true))
 
     expect(b.current.settings.toolbarDefaultExpanded).toBe(true)
+  })
+
+  it('updates disableContextMenu and persists', () => {
+    const { result } = renderHook(() => useSettings())
+    act(() => result.current.updateSetting('disableContextMenu', false))
+
+    expect(result.current.settings.disableContextMenu).toBe(false)
+
+    const stored = JSON.parse(localStorage.getItem('termote-settings')!)
+    expect(stored.disableContextMenu).toBe(false)
+  })
+
+  it('restores disableContextMenu from localStorage', () => {
+    localStorage.setItem(
+      'termote-settings',
+      JSON.stringify({ disableContextMenu: false }),
+    )
+    const { result } = renderHook(() => useSettings())
+    expect(result.current.settings.disableContextMenu).toBe(false)
   })
 })

--- a/pwa/src/hooks/use-settings.ts
+++ b/pwa/src/hooks/use-settings.ts
@@ -7,11 +7,13 @@ export type ImeSendBehavior = 'send-only' | 'send-enter'
 export interface Settings {
   imeSendBehavior: ImeSendBehavior
   toolbarDefaultExpanded: boolean
+  disableContextMenu: boolean
 }
 
 const DEFAULTS: Settings = {
   imeSendBehavior: 'send-only',
   toolbarDefaultExpanded: false,
+  disableContextMenu: true,
 }
 
 // Listeners for useSyncExternalStore

--- a/pwa/src/utils/terminal-bridge.test.ts
+++ b/pwa/src/utils/terminal-bridge.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import {
+  blockContextMenu,
   isInCopyMode,
   isTerminalDisconnected,
   isTerminalReady,
@@ -9,6 +10,7 @@ import {
   setTerminalFontSize,
   setTerminalTheme,
   toggleTmuxCopyMode,
+  unblockContextMenu,
 } from './terminal-bridge'
 
 // Mock xterm terminal instance
@@ -248,6 +250,62 @@ describe('isTerminalReady', () => {
   it('returns false when term is not available', () => {
     const iframe = createMockIframe(null)
     expect(isTerminalReady(iframe)).toBe(false)
+  })
+})
+
+describe('blockContextMenu', () => {
+  it('blocks context menu on iframe document', () => {
+    const iframe = createMockIframe(createMockTerm())
+    const result = blockContextMenu(iframe)
+    expect(result).toBe(true)
+
+    const event = new Event('contextmenu', { cancelable: true })
+    iframe.contentDocument!.dispatchEvent(event)
+    expect(event.defaultPrevented).toBe(true)
+  })
+
+  it('is idempotent — second call returns true without re-adding', () => {
+    const iframe = createMockIframe(createMockTerm())
+    expect(blockContextMenu(iframe)).toBe(true)
+    expect(blockContextMenu(iframe)).toBe(true)
+  })
+
+  it('returns false when iframe is null', () => {
+    expect(blockContextMenu(null)).toBe(false)
+  })
+})
+
+describe('unblockContextMenu', () => {
+  it('removes context menu block', () => {
+    const iframe = createMockIframe(createMockTerm())
+    blockContextMenu(iframe)
+
+    const result = unblockContextMenu(iframe)
+    expect(result).toBe(true)
+
+    const event = new Event('contextmenu', { cancelable: true })
+    iframe.contentDocument!.dispatchEvent(event)
+    expect(event.defaultPrevented).toBe(false)
+  })
+
+  it('returns true when not blocked (no-op)', () => {
+    const iframe = createMockIframe(createMockTerm())
+    expect(unblockContextMenu(iframe)).toBe(true)
+  })
+
+  it('returns false when iframe is null', () => {
+    expect(unblockContextMenu(null)).toBe(false)
+  })
+
+  it('allows re-blocking after unblock', () => {
+    const iframe = createMockIframe(createMockTerm())
+    blockContextMenu(iframe)
+    unblockContextMenu(iframe)
+    blockContextMenu(iframe)
+
+    const event = new Event('contextmenu', { cancelable: true })
+    iframe.contentDocument!.dispatchEvent(event)
+    expect(event.defaultPrevented).toBe(true)
   })
 })
 

--- a/pwa/src/utils/terminal-bridge.ts
+++ b/pwa/src/utils/terminal-bridge.ts
@@ -388,3 +388,37 @@ export function isTerminalReady(iframe: HTMLIFrameElement | null): boolean {
   const term = getTerm(iframe)
   return term !== null && (!!term.options || !!term.setOption)
 }
+
+// WeakMap keyed on Document so handler ref survives remounts but is GC'd with the iframe
+const contextMenuHandlers = new WeakMap<Document, (e: Event) => void>()
+
+export function blockContextMenu(iframe: HTMLIFrameElement | null): boolean {
+  try {
+    const doc = iframe?.contentDocument
+    if (!doc) return false
+    if (contextMenuHandlers.has(doc)) return true
+
+    const handler = (e: Event) => e.preventDefault()
+    contextMenuHandlers.set(doc, handler)
+    doc.addEventListener('contextmenu', handler)
+    return true
+  } catch {
+    return false
+  }
+}
+
+export function unblockContextMenu(iframe: HTMLIFrameElement | null): boolean {
+  try {
+    const doc = iframe?.contentDocument
+    if (!doc) return false
+
+    const handler = contextMenuHandlers.get(doc)
+    if (!handler) return true
+
+    doc.removeEventListener('contextmenu', handler)
+    contextMenuHandlers.delete(doc)
+    return true
+  } catch {
+    return false
+  }
+}


### PR DESCRIPTION
## Summary
- Add user-configurable setting to block/unblock right-click context menu on terminal area
- Default enabled (blocked) to prevent accidental menu popups on mobile
- Users can toggle it off in Settings > Preferences
- Extract reusable `ToggleRow` component for boolean settings
- Use `WeakMap`-based handler tracking for clean block/unblock lifecycle

## Changes
- `use-settings.ts`: Add `disableContextMenu: boolean` (default: `true`)
- `settings-modal.tsx`: Extract `ToggleRow` component, add context menu toggle
- `terminal-bridge.ts`: Refactor `blockContextMenu` + add `unblockContextMenu` with `WeakMap`
- `terminal-frame.tsx`: Pass `disableContextMenu` prop, apply conditionally
- `App.tsx`: Wire setting to `TerminalFrame`

## Test plan
- [x] Unit tests: `blockContextMenu`/`unblockContextMenu` (idempotent, null-safe, re-blockable)
- [x] Unit tests: `disableContextMenu` setting default, update, persist, restore
- [x] E2E: Toggle disable context menu on/off in preferences
- [x] E2E: Setting persists after page reload
- [x] All 77 unit tests pass