### PR TITLE
docs: add Claude Code setup guide + troubleshooting page

### DIFF
--- a/website/src/content/docs/troubleshooting.mdx
+++ b/website/src/content/docs/troubleshooting.mdx
@@ -1,0 +1,146 @@
+---
+title: Troubleshooting
+description: Common issues and solutions for Termote
+---
+
+import { Aside } from "@astrojs/starlight/components";
+
+## Installation Issues
+
+### Docker not found
+
+```
+Error: Docker is not installed
+```
+
+Install Docker Desktop from [docker.com](https://www.docker.com/products/docker-desktop/) or use a package manager:
+
+```bash
+# macOS
+brew install --cask docker
+
+# Ubuntu/Debian
+sudo apt-get install docker.io
+```
+
+### Port 7680 already in use
+
+```
+Error: Port 7680 is already in use
+```
+
+Another service is using the default port. Either stop the conflicting service or change Termote's port:
+
+```bash
+# Check what's using port 7680
+lsof -i :7680
+
+# Use a different port
+TERMOTE_PORT=8080 ./scripts/termote.sh install native
+```
+
+### Permission denied on Docker socket
+
+```
+Error: permission denied while trying to connect to the Docker daemon socket
+```
+
+Add your user to the docker group:
+
+```bash
+sudo usermod -aG docker $USER
+# Log out and back in for the change to take effect
+```
+
+## Connection Issues
+
+### Cannot access from phone
+
+1. **Check your IP**: Run `ifconfig` or `ip addr` and use your LAN IP (e.g., `192.168.1.x`)
+2. **Check firewall**: Ensure port 7680 is open
+3. **Use `--lan` flag**: This binds to `0.0.0.0` instead of `127.0.0.1`
+
+```bash
+./scripts/termote.sh install native --lan
+```
+
+### WebSocket connection failed
+
+If the terminal connects but shows no output:
+
+1. Check if tmux is running: `tmux ls`
+2. Check if ttyd is running: `ps aux | grep ttyd`
+3. Restart Termote: `./scripts/termote.sh install native`
+
+### PWA not updating
+
+If Termote's PWA shows an old version:
+
+1. Open browser DevTools → Application → Service Workers
+2. Click "Unregister" on the Termote service worker
+3. Hard refresh (Cmd+Shift+R / Ctrl+Shift+R)
+4. Re-install the PWA
+
+## Session Issues
+
+### Sessions lost after reboot
+
+Termote uses tmux sessions, which don't persist across reboots by default. To auto-start Termote on boot:
+
+**macOS (launchd):**
+
+```bash
+./scripts/termote.sh link  # Creates global command
+# Then add to Login Items in System Preferences
+```
+
+**Linux (systemd):**
+
+```bash
+# Create a user service
+mkdir -p ~/.config/systemd/user/
+cat > ~/.config/systemd/user/termote.service << EOF
+[Unit]
+Description=Termote
+After=network.target
+
+[Service]
+ExecStart=%h/.local/bin/termote install native --lan
+Restart=on-failure
+
+[Install]
+WantedBy=default.target
+EOF
+
+systemctl --user enable termote
+systemctl --user start termote
+```
+
+### Terminal appears frozen
+
+- **Try Ctrl+C** (or swipe left on mobile) to interrupt any running command
+- **Check tmux**: The session might be in copy mode — press `q` to exit
+- **Reconnect**: Close and reopen the Termote tab
+
+## Performance
+
+### High CPU usage
+
+If ttyd uses high CPU:
+
+1. Reduce terminal scrollback: Set `TERMOTE_SCROLLBACK=1000` in your environment
+2. Close unused sessions
+3. Avoid commands that produce excessive output (pipe through `less` or `tail`)
+
+### Slow on cellular connection
+
+Termote works best on Wi-Fi. For cellular:
+
+- Use [Tailscale](/installation/tailscale/) for a more stable connection
+- Enable compression in your reverse proxy if using one
+- Keep terminal output concise
+
+<Aside type="tip">
+  Still having issues? [Open a GitHub issue](https://github.com/lamngockhuong/termote/issues) with your OS, Termote version (`termote --version`), and the full error message.
+</Aside>
+

--- a/website/src/content/docs/usage/claude-code.mdx
+++ b/website/src/content/docs/usage/claude-code.mdx
@@ -1,0 +1,117 @@
+---
+title: Claude Code Setup
+description: Control Claude Code from your phone with Termote
+---
+
+import { Aside, Steps } from "@astrojs/starlight/components";
+
+## Overview
+
+Termote was built with Claude Code in mind. This guide walks you through setting up Termote to control Claude Code sessions from your phone or tablet — perfect for reviewing code, running commands, or pair programming on the go.
+
+## Prerequisites
+
+- Claude Code installed (`npm install -g @anthropic-ai/claude-code`)
+- Termote installed in [Native mode](/installation/native/) (recommended for Claude Code access)
+
+<Aside type="caution">
+  Container mode runs in an isolated environment and won't have access to your host's Claude Code installation. Use **Native mode** to control Claude Code.
+</Aside>
+
+## Setup
+
+<Steps>
+
+1. **Install Termote in native mode**
+
+   ```bash
+   curl -fsSL https://raw.githubusercontent.com/lamngockhuong/termote/main/scripts/get.sh | bash -s -- --native --lan
+   ```
+
+   The `--lan` flag makes Termote accessible from your phone on the same network.
+
+2. **Open Termote on your phone**
+
+   Navigate to the URL shown after installation (e.g., `http://192.168.1.100:7680`).
+
+   <Aside type="tip">
+     Install Termote as a PWA for the best mobile experience — tap the browser's "Add to Home Screen" option.
+   </Aside>
+
+3. **Create a Claude Code session**
+
+   In the Termote terminal, start Claude Code:
+
+   ```bash
+   claude
+   ```
+
+   Or start with a specific project:
+
+   ```bash
+   cd ~/my-project && claude
+   ```
+
+4. **Start coding from your phone!**
+
+   Use the virtual keyboard toolbar for special keys (Tab, Ctrl, Esc, arrows) and gestures for quick actions.
+
+</Steps>
+
+## Tips for Mobile Usage
+
+### Use Gestures
+
+- **Swipe left** → `Ctrl+C` (cancel current operation)
+- **Swipe right** → `Tab` (accept suggestions)
+- **Swipe up/down** → Browse command history
+
+### Multiple Sessions
+
+Create separate Termote sessions for different tasks:
+
+- **Session 1**: Claude Code for your main project
+- **Session 2**: A regular shell for running tests or checking logs
+- **Session 3**: Claude Code for a different repo
+
+Switch between sessions using the sidebar.
+
+### Voice to Code Workflow
+
+1. Use your phone's voice-to-text to dictate prompts
+2. Termote sends the text to Claude Code
+3. Review Claude's output on your phone
+4. Swipe right to accept, swipe left to cancel
+
+### Remote Access via Tailscale
+
+For secure access outside your local network:
+
+```bash
+curl -fsSL .../get.sh | bash -s -- --native --tailscale my-machine
+```
+
+See the [Tailscale guide](/installation/tailscale/) for full setup.
+
+## Troubleshooting
+
+### Claude Code not found
+
+If you see `command not found: claude`, ensure Claude Code is installed globally:
+
+```bash
+npm install -g @anthropic-ai/claude-code
+```
+
+In **native mode**, Termote inherits your shell's PATH, so globally installed tools are available automatically.
+
+### Session disconnects
+
+If your Termote session disconnects while Claude Code is running, don't worry — tmux keeps the session alive. Reconnect to Termote and your Claude Code session will be exactly where you left it.
+
+### Slow on mobile
+
+- Enable **Fullscreen mode** to reduce browser UI overhead
+- Close other browser tabs
+- Use a stable Wi-Fi connection (cellular can add latency)
+


### PR DESCRIPTION
## What this does

Adds two new documentation pages to the Termote website:

### 1. Claude Code Setup Guide (`usage/claude-code.mdx`)
- Step-by-step setup for controlling Claude Code via Termote
- Mobile usage tips (gestures, voice-to-code workflow)
- Multi-session strategies
- Common issues specific to Claude Code

### 2. Troubleshooting Guide (`troubleshooting.mdx`)
- Installation issues (Docker, ports, permissions)
- Connection issues (LAN access, WebSocket, PWA)
- Session management (persistence across reboots, frozen terminals)
- Performance tips (CPU, cellular)
- Links to GitHub Issues for further help

## Why

Termote is built for controlling Claude Code from mobile, but the docs don't have a dedicated guide for this primary use case. The Claude Code guide fills that gap. The troubleshooting page reduces GitHub issues by covering common problems upfront.

## Testing

Both files follow the existing Starlight/Astro MDX format and use the same components (`Aside`, `Steps`) as other docs pages.