### PR TITLE
fix(pwa): fix settings menu z-index overlap with terminal states

### DIFF
--- a/pwa/src/components/terminal-frame.tsx
+++ b/pwa/src/components/terminal-frame.tsx
@@ -163,7 +163,7 @@ export const TerminalFrame = forwardRef<TerminalFrameHandle, Props>(
 
     if (tokenError) {
       return (
-        <div className="flex-1 flex flex-col items-center justify-center text-red-400 relative z-10">
+        <div className="flex-1 flex flex-col items-center justify-center text-red-400">
           <p>{tokenError}</p>
           <button
             onClick={loadTerminal}
@@ -176,7 +176,7 @@ export const TerminalFrame = forwardRef<TerminalFrameHandle, Props>(
     }
     if (loading || !terminalSrc) {
       return (
-        <div className="flex-1 flex items-center justify-center text-zinc-400 relative z-10">
+        <div className="flex-1 flex items-center justify-center text-zinc-400">
           Connecting...
         </div>
       )


### PR DESCRIPTION
## Summary
- Fix settings menu dropdown rendering behind "Connecting..." and error states
- Remove unnecessary `relative z-10` from loading/error divs in terminal-frame.tsx

## Test plan
- [ ] Open settings menu while terminal shows "Connecting..."
- [ ] Open settings menu when terminal shows "Failed to load" error
- [ ] Verify dropdown renders above these states