### PR TITLE
docs(pwa): add paste button to help modal

### DIFF
--- a/pwa/src/components/help-modal.tsx
+++ b/pwa/src/components/help-modal.tsx
@@ -38,6 +38,7 @@ const TOOLBAR_GUIDE: GuideSection[] = [
       { key: 'Shift', desc: 'Toggle Shift modifier (sticky)' },
       { key: '↑↓←→', desc: 'Arrow keys' },
       { key: '⏱ History', desc: 'Toggle tmux copy mode' },
+      { key: '📋 Paste', desc: 'Paste from tmux buffer' },
       { key: '⇈⇊ Scroll', desc: 'Page up/down in copy mode' },
     ],
   },


### PR DESCRIPTION
## Summary
- Add missing paste button (📋) documentation to the Toolbar Guide in help modal
- The paste button was added in #119 but not documented in the usage guide

## Test plan
- [x] Open help modal → Toolbar tab
- [x] Verify paste button entry is visible