### PR TITLE
feat(pwa): add configurable session poll interval setting

### DIFF
--- a/docs/code-standards.md
+++ b/docs/code-standards.md
@@ -67,12 +67,14 @@ export interface Settings {
   imeSendBehavior: "send-only" | "send-enter";
   toolbarDefaultExpanded: boolean;
   disableContextMenu: boolean;
+  pollInterval: number; // seconds
 }
 
 const DEFAULTS: Settings = {
   imeSendBehavior: "send-only",
   toolbarDefaultExpanded: false,
   disableContextMenu: true,
+  pollInterval: 5,
 };
 
 function getSnapshot() {

--- a/docs/codebase-summary.md
+++ b/docs/codebase-summary.md
@@ -111,18 +111,19 @@ Virtual keyboard for mobile:
 - Haptic feedback on key press
 - Respects `defaultExpanded` prop from settings
 
-### settings-modal.tsx (~181 lines)
+### settings-modal.tsx (~207 lines)
 
-Settings dialog with radio buttons and toggles:
+Settings dialog with radio buttons, toggles, and dropdown:
 
 - **IME send behavior**: "Send text only" (default) or "Send + Enter" (auto-press Enter after text)
 - **Toolbar default expanded**: Toggle to show all keys on load (vs. collapsed by default)
 - **Disable right-click menu**: Toggle to disable context menu on terminal (default: enabled)
+- **Session poll interval**: Dropdown to set sync frequency (3s, 5s, 10s, 15s, 30s, 1m, 2m, 5m; default: 5s)
 - Uses `ToggleRow` helper component for consistent toggle styling
 - Accessible dialog with custom styling
 - Persists changes via `useSettings()` hook
 
-### use-settings.ts (~68 lines)
+### use-settings.ts (~70 lines)
 
 Settings state management using `useSyncExternalStore`:
 
@@ -131,8 +132,9 @@ Settings state management using `useSyncExternalStore`:
   - `imeSendBehavior`: 'send-only' | 'send-enter'
   - `toolbarDefaultExpanded`: boolean
   - `disableContextMenu`: boolean (default: true)
+  - `pollInterval`: number in seconds (default: 5, range: 3-300 for 3s-5m)
 - `updateSetting()` callback to update individual settings
-- Defaults to send-only + collapsed toolbar + context menu disabled
+- Defaults to send-only + collapsed toolbar + context menu disabled + 5s poll interval
 
 ### use-gestures.ts (~53 lines)
 
@@ -149,7 +151,7 @@ Session management + tmux sync:
 - Sessions loaded from tmux windows via API
 - LocalStorage for metadata (icons, descriptions)
 - tmux window create/select/kill via API
-- Polling every 5s for external changes
+- Polling interval configurable via `pollInterval` parameter (seconds, default: 5)
 
 ### use-tmux-api.ts (~56 lines)
 

--- a/docs/project-overview-pdr.md
+++ b/docs/project-overview-pdr.md
@@ -25,22 +25,23 @@ PWA that wraps ttyd terminals with:
 
 ## Features
 
-| Feature                | Description                                             |
-| ---------------------- | ------------------------------------------------------- |
-| Session Management     | Create, switch, delete tmux windows via UI              |
-| Virtual Keyboard       | Touch-friendly buttons for special keys                 |
-| Keyboard Gestures      | Swipe, long-press, pinch for common shortcuts           |
-| Theme Support          | Light/dark/system theme toggle (in-place switching)     |
-| Font Scaling           | Adjustable terminal font size (6-24px)                  |
-| Fullscreen Mode        | Desktop-only fullscreen terminal view                   |
-| Context Menu Control   | Disable right-click menu on terminal (default: enabled) |
-| Settings / Preferences | IME behavior, toolbar default, context menu             |
-| Persistent Settings    | User preferences saved to localStorage                  |
-| Session Cookie Auth    | Prevents double basic auth prompt on mobile             |
-| iOS Safe Area          | Respects status bar safe area inset                     |
-| Basic Authentication   | HTTP basic auth + iframe-only terminal access           |
-| Brute-force Protection | Rate limiter (5 failed attempts/min per IP)             |
-| Self-Update            | Fetch & install latest release, preserve config         |
+| Feature                | Description                                                |
+| ---------------------- | ---------------------------------------------------------- |
+| Session Management     | Create, switch, delete tmux windows via UI                 |
+| Virtual Keyboard       | Touch-friendly buttons for special keys                    |
+| Keyboard Gestures      | Swipe, long-press, pinch for common shortcuts              |
+| Theme Support          | Light/dark/system theme toggle (in-place switching)        |
+| Font Scaling           | Adjustable terminal font size (6-24px)                     |
+| Fullscreen Mode        | Desktop-only fullscreen terminal view                      |
+| Context Menu Control   | Disable right-click menu on terminal (default: enabled)    |
+| Settings / Preferences | IME behavior, toolbar default, context menu, poll interval |
+| Persistent Settings    | User preferences saved to localStorage                     |
+| Session Poll Interval  | Configurable sync frequency (3s-5m) to reduce server spam  |
+| Session Cookie Auth    | Prevents double basic auth prompt on mobile                |
+| iOS Safe Area          | Respects status bar safe area inset                        |
+| Basic Authentication   | HTTP basic auth + iframe-only terminal access              |
+| Brute-force Protection | Rate limiter (5 failed attempts/min per IP)                |
+| Self-Update            | Fetch & install latest release, preserve config            |
 
 ## Target Users
 

--- a/docs/system-architecture.md
+++ b/docs/system-architecture.md
@@ -54,7 +54,8 @@ React SPA with:
 - **Session Sidebar**: Switch between tmux windows, add/edit/remove (collapsible on desktop)
 - **Keyboard Toolbar**: Virtual keys, Ctrl combos, scroll controls (respects default expanded setting)
 - **Settings Menu**: Theme toggle (light/dark/system), Clear Cache & Reload, Preferences
-- **Settings Modal**: IME behavior, toolbar default expanded, context menu control (disable right-click)
+- **Settings Modal**: IME behavior, toolbar default expanded, context menu control, session poll interval
+- **Session Poll Interval**: Configurable sync frequency (3s-5m, default 5s) to control API polling rate
 - **Context Menu Control**: Block/unblock right-click on terminal via iframe postMessage
 - **Font Controls**: Adjustable font size (6-24px)
 - **Fullscreen Toggle**: Desktop-only fullscreen mode via Fullscreen API

--- a/pwa/e2e/ui-features.spec.ts
+++ b/pwa/e2e/ui-features.spec.ts
@@ -339,6 +339,42 @@ test.describe('preferences modal', () => {
     await expect(toggleAfter).toHaveAttribute('aria-checked', 'false')
   })
 
+  test('changes poll interval', async ({ page }) => {
+    await page.click('button[aria-label="Settings"]')
+    await page.click('text=Preferences')
+    await page.waitForTimeout(200)
+
+    // Change poll interval to 30s
+    const select = page.locator('select')
+    await select.selectOption('30')
+    await page.waitForTimeout(100)
+
+    // Verify persisted to localStorage
+    const stored = await page.evaluate(() => localStorage.getItem('termote-settings'))
+    expect(JSON.parse(stored!).pollInterval).toBe(30)
+  })
+
+  test('poll interval persists after reload', async ({ page }) => {
+    await page.click('button[aria-label="Settings"]')
+    await page.click('text=Preferences')
+    await page.waitForTimeout(200)
+
+    // Set to 60 (1m)
+    await page.locator('select').selectOption('60')
+    await page.waitForTimeout(100)
+
+    // Reload
+    await page.keyboard.press('Escape')
+    await page.reload()
+    await page.waitForSelector('iframe[title="Terminal"]', { timeout: 10000 })
+
+    // Reopen and verify
+    await page.click('button[aria-label="Settings"]')
+    await page.click('text=Preferences')
+    await page.waitForTimeout(200)
+    await expect(page.locator('select')).toHaveValue('60')
+  })
+
   test('preferences persist after page reload', async ({ page }) => {
     // Open and change setting
     await page.click('button[aria-label="Settings"]')

--- a/pwa/src/App.tsx
+++ b/pwa/src/App.tsx
@@ -58,7 +58,7 @@ export default function App() {
     addSession,
     removeSession,
     updateSession,
-  } = useLocalSessions()
+  } = useLocalSessions(settings.pollInterval)
   const { fontSize, increase, decrease } = useFontSize()
   const { resolvedTheme } = useTheme()
   const { isFullscreen, toggleFullscreen } = useFullscreen()

--- a/pwa/src/components/settings-modal.tsx
+++ b/pwa/src/components/settings-modal.tsx
@@ -185,7 +185,8 @@ export function SettingsModal({
                 Session poll interval
               </p>
               <p className="text-xs text-zinc-500 dark:text-zinc-400 mt-0.5">
-                How often to sync session list ({formatSeconds(settings.pollInterval)})
+                How often to sync session list (
+                {formatSeconds(settings.pollInterval)})
               </p>
             </div>
             <select

--- a/pwa/src/components/settings-modal.tsx
+++ b/pwa/src/components/settings-modal.tsx
@@ -50,6 +50,10 @@ function ToggleRow({
   )
 }
 
+const formatSeconds = (s: number) => (s >= 60 ? `${s / 60}m` : `${s}s`)
+
+const POLL_INTERVAL_OPTIONS = [3, 5, 10, 15, 30, 60, 120, 300]
+
 const IME_SEND_OPTIONS: {
   value: ImeSendBehavior
   label: string
@@ -174,6 +178,30 @@ export function SettingsModal({
               )
             }
           />
+
+          <div className="flex items-center justify-between">
+            <div>
+              <p className="text-sm font-medium text-zinc-700 dark:text-zinc-300">
+                Session poll interval
+              </p>
+              <p className="text-xs text-zinc-500 dark:text-zinc-400 mt-0.5">
+                How often to sync session list ({formatSeconds(settings.pollInterval)})
+              </p>
+            </div>
+            <select
+              value={settings.pollInterval}
+              onChange={(e) =>
+                onUpdateSetting('pollInterval', Number(e.target.value))
+              }
+              className="rounded-lg border border-zinc-200 dark:border-zinc-600 bg-white dark:bg-zinc-700 text-sm text-zinc-900 dark:text-white px-2 py-1.5"
+            >
+              {POLL_INTERVAL_OPTIONS.map((v) => (
+                <option key={v} value={v}>
+                  {formatSeconds(v)}
+                </option>
+              ))}
+            </select>
+          </div>
         </div>
       </div>
     </dialog>

--- a/pwa/src/hooks/use-local-sessions.ts
+++ b/pwa/src/hooks/use-local-sessions.ts
@@ -43,7 +43,7 @@ function windowToSession(
   }
 }
 
-export function useLocalSessions() {
+export function useLocalSessions(pollInterval = 5) {
   const [sessions, setSessions] = useState<Session[]>([])
   const [activeSession, setActiveSession] = useState<Session | null>(null)
   const [isReady, setIsReady] = useState(false)
@@ -98,10 +98,10 @@ export function useLocalSessions() {
   // Initial fetch and periodic refresh
   useEffect(() => {
     refreshSessions()
-    // Refresh every 5 seconds to sync across browsers
-    const interval = setInterval(refreshSessions, 5000)
+    const ms = Math.max(pollInterval, 1) * 1000
+    const interval = setInterval(refreshSessions, ms)
     return () => clearInterval(interval)
-  }, [refreshSessions])
+  }, [refreshSessions, pollInterval])
 
   const switchSession = useCallback(
     async (sessionId: string) => {

--- a/pwa/src/hooks/use-settings.test.ts
+++ b/pwa/src/hooks/use-settings.test.ts
@@ -12,6 +12,7 @@ describe('useSettings', () => {
     expect(result.current.settings.imeSendBehavior).toBe('send-only')
     expect(result.current.settings.toolbarDefaultExpanded).toBe(false)
     expect(result.current.settings.disableContextMenu).toBe(true)
+    expect(result.current.settings.pollInterval).toBe(5)
   })
 
   it('restores saved settings from localStorage', () => {
@@ -36,6 +37,7 @@ describe('useSettings', () => {
     expect(result.current.settings.imeSendBehavior).toBe('send-enter')
     expect(result.current.settings.toolbarDefaultExpanded).toBe(false)
     expect(result.current.settings.disableContextMenu).toBe(true)
+    expect(result.current.settings.pollInterval).toBe(5)
   })
 
   it('handles corrupt localStorage gracefully', () => {
@@ -82,5 +84,24 @@ describe('useSettings', () => {
     )
     const { result } = renderHook(() => useSettings())
     expect(result.current.settings.disableContextMenu).toBe(false)
+  })
+
+  it('updates pollInterval and persists', () => {
+    const { result } = renderHook(() => useSettings())
+    act(() => result.current.updateSetting('pollInterval', 30))
+
+    expect(result.current.settings.pollInterval).toBe(30)
+
+    const stored = JSON.parse(localStorage.getItem('termote-settings')!)
+    expect(stored.pollInterval).toBe(30)
+  })
+
+  it('restores pollInterval from localStorage', () => {
+    localStorage.setItem(
+      'termote-settings',
+      JSON.stringify({ pollInterval: 120 }),
+    )
+    const { result } = renderHook(() => useSettings())
+    expect(result.current.settings.pollInterval).toBe(120)
   })
 })

--- a/pwa/src/hooks/use-settings.ts
+++ b/pwa/src/hooks/use-settings.ts
@@ -8,12 +8,14 @@ export interface Settings {
   imeSendBehavior: ImeSendBehavior
   toolbarDefaultExpanded: boolean
   disableContextMenu: boolean
+  pollInterval: number // seconds between session list refreshes
 }
 
 const DEFAULTS: Settings = {
   imeSendBehavior: 'send-only',
   toolbarDefaultExpanded: false,
   disableContextMenu: true,
+  pollInterval: 5,
 }
 
 // Listeners for useSyncExternalStore

--- a/website/src/content/docs/usage/settings.mdx
+++ b/website/src/content/docs/usage/settings.mdx
@@ -34,6 +34,14 @@ Blocks the browser context menu (right-click / long-press) on the terminal area 
 | On     | Context menu is blocked on terminal     | ✓       |
 | Off    | Browser default context menu is allowed |         |
 
+## Session Poll Interval
+
+Controls how often the app syncs the session list from the server. Lower values keep multi-device views in sync faster; higher values reduce server load when using a single device.
+
+| Option                            | Default |
+| --------------------------------- | ------- |
+| 3s, 5s, 10s, 15s, 30s, 1m, 2m, 5m | 5s ✓    |
+
 ## Persistence
 
 All settings are saved to your browser's local storage (`termote-settings` key) and persist across sessions. Clearing browser data or using "Clear Cache & Reload" will reset settings to defaults.

--- a/website/src/content/docs/vi/usage/settings.mdx
+++ b/website/src/content/docs/vi/usage/settings.mdx
@@ -29,10 +29,18 @@ Truy cập cài đặt qua **biểu tượng bánh răng** (⚙) ở header → 
 
 Chặn menu ngữ cảnh trình duyệt (nhấn chuột phải / nhấn giữ) trên vùng terminal để tránh gián đoạn.
 
-| Tùy chọn | Hành vi                                      | Mặc định |
-| --------- | -------------------------------------------- | -------- |
-| Bật       | Menu ngữ cảnh bị chặn trên terminal          | ✓        |
-| Tắt       | Hiển thị menu ngữ cảnh mặc định trình duyệt |          |
+| Tùy chọn | Hành vi                                     | Mặc định |
+| -------- | ------------------------------------------- | -------- |
+| Bật      | Menu ngữ cảnh bị chặn trên terminal         | ✓        |
+| Tắt      | Hiển thị menu ngữ cảnh mặc định trình duyệt |          |
+
+## Chu kỳ đồng bộ session
+
+Điều chỉnh tần suất ứng dụng đồng bộ danh sách session từ server. Giá trị thấp giúp đồng bộ nhanh khi dùng nhiều thiết bị; giá trị cao giảm tải server khi chỉ dùng một thiết bị.
+
+| Tùy chọn                          | Mặc định |
+| --------------------------------- | -------- |
+| 3s, 5s, 10s, 15s, 30s, 1m, 2m, 5m | 5s ✓     |
 
 ## Lưu trữ
 


### PR DESCRIPTION
## Summary
- Add `pollInterval` setting (3s, 5s, 10s, 15s, 30s, 1m, 2m, 5m) to control session list sync frequency
- Default 5s, persisted in localStorage
- Reduces unnecessary API requests when multi-device sync is not needed

## Changes
- `use-settings.ts`: Added `pollInterval` to Settings interface
- `use-local-sessions.ts`: Accepts configurable poll interval instead of hardcoded 5s
- `settings-modal.tsx`: Added dropdown selector with time formatting helper
- `App.tsx`: Passes `settings.pollInterval` to `useLocalSessions()`
- Updated docs (EN + VI), website docs, and code standards
- Added unit tests (2) and e2e tests (2)

## Test plan
- [ ] Open Settings > Preferences, verify poll interval dropdown appears with default 5s
- [ ] Change interval to 1m, verify localStorage persists the value
- [ ] Reload page, verify setting is restored
- [ ] Run `pnpm vitest run src/hooks/use-settings.test.ts` — 10 tests pass
- [ ] Run `pnpm test:e2e` — poll interval e2e tests pass