### PR TITLE
feat(pwa): add gesture hints overlay and configurable paste source

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -195,18 +195,21 @@ The `update` command:
 
 ## Key Files
 
-| File                                      | Purpose                                             |
-| ----------------------------------------- | --------------------------------------------------- |
-| `pwa/src/App.tsx`                         | Main app with gestures, toolbar, settings, sessions |
-| `pwa/src/components/keyboard-toolbar.tsx` | Virtual keyboard for mobile                         |
-| `pwa/src/components/settings-modal.tsx`   | Settings dialog (IME send behavior, toolbar expand) |
-| `pwa/src/hooks/use-settings.ts`           | Settings state with localStorage persistence        |
-| `pwa/src/hooks/use-gestures.ts`           | Hammer.js gesture handling                          |
-| `tmux-api/main.go`                        | Entry point                                         |
-| `tmux-api/serve.go`                       | Server (PWA, WebSocket proxy, auth)                 |
-| `tmux-api/tmux.go`                        | tmux API handlers                                   |
-| `Dockerfile`                              | Docker mode container                               |
-| `entrypoint.sh`                           | Container entrypoint                                |
+| File                                           | Purpose                                             |
+| ---------------------------------------------- | --------------------------------------------------- |
+| `pwa/src/App.tsx`                              | Main app with gestures, toolbar, settings, sessions |
+| `pwa/src/components/keyboard-toolbar.tsx`      | Virtual keyboard for mobile                         |
+| `pwa/src/components/settings-modal.tsx`        | Settings dialog (IME, paste source, toolbar, etc.)  |
+| `pwa/src/components/gesture-hints-overlay.tsx` | First-time gesture tutorial overlay (mobile)        |
+| `pwa/src/components/toast.tsx`                 | Toast notification component                        |
+| `pwa/src/hooks/use-settings.ts`                | Settings state with localStorage persistence        |
+| `pwa/src/hooks/use-gestures.ts`                | Hammer.js gesture handling                          |
+| `pwa/src/utils/terminal-bridge.ts`             | Terminal iframe communication + clipboard paste     |
+| `tmux-api/main.go`                             | Entry point                                         |
+| `tmux-api/serve.go`                            | Server (PWA, WebSocket proxy, auth)                 |
+| `tmux-api/tmux.go`                             | tmux API handlers                                   |
+| `Dockerfile`                                   | Docker mode container                               |
+| `entrypoint.sh`                                | Container entrypoint                                |
 
 ## Container Runtime Support
 

--- a/docs/codebase-summary.md
+++ b/docs/codebase-summary.md
@@ -14,14 +14,16 @@ termote/
 │   │   ├── components/
 │   │   │   ├── about-modal.tsx              # About dialog
 │   │   │   ├── bottom-navigation.tsx        # Mobile bottom nav
+│   │   │   ├── gesture-hints-overlay.tsx    # First-time gesture tutorial (mobile)
 │   │   │   ├── help-modal.tsx               # Help/gestures guide
 │   │   │   ├── icon-picker.tsx              # Emoji icon selector
 │   │   │   ├── keyboard-toolbar.tsx         # Virtual keyboard buttons
 │   │   │   ├── session-sidebar.tsx          # Session switcher sidebar
 │   │   │   ├── settings-menu.tsx            # Settings dropdown
-│   │   │   ├── settings-modal.tsx           # Settings dialog (IME, toolbar, context menu)
+│   │   │   ├── settings-modal.tsx           # Settings dialog (IME, toolbar, paste, etc.)
 │   │   │   ├── swipeable-session-item.tsx   # Swipe-to-delete session
 │   │   │   ├── terminal-frame.tsx           # Terminal iframe wrapper (ttyd)
+│   │   │   ├── toast.tsx                    # Toast notification component
 │   │   │   └── theme-toggle.tsx             # Theme switcher buttons
 │   │   ├── contexts/
 │   │   │   ├── theme-context.tsx            # Theme provider (light/dark/system)
@@ -79,7 +81,7 @@ termote/
 
 ## Key Components
 
-### App.tsx (~315 lines)
+### App.tsx (~400 lines)
 
 Main orchestrator combining:
 
@@ -90,6 +92,8 @@ Main orchestrator combining:
 - Font size controls (A-/A+)
 - Fullscreen toggle (desktop only, Fullscreen API)
 - Gesture handlers → terminal commands (mobile only)
+- Gesture hints overlay (first mobile visit)
+- Toast notifications for clipboard errors
 
 ### terminal-frame.tsx (~197 lines)
 
@@ -111,19 +115,21 @@ Virtual keyboard for mobile:
 - Haptic feedback on key press
 - Respects `defaultExpanded` prop from settings
 
-### settings-modal.tsx (~207 lines)
+### settings-modal.tsx (~270 lines)
 
 Settings dialog with radio buttons, toggles, and dropdown:
 
 - **IME send behavior**: "Send text only" (default) or "Send + Enter" (auto-press Enter after text)
+- **Paste button source**: System clipboard (default) or tmux buffer
 - **Toolbar default expanded**: Toggle to show all keys on load (vs. collapsed by default)
 - **Disable right-click menu**: Toggle to disable context menu on terminal (default: enabled)
 - **Session poll interval**: Dropdown to set sync frequency (3s, 5s, 10s, 15s, 30s, 1m, 2m, 5m; default: 5s)
+- **Show Gesture Hints**: Button to re-show gesture tutorial (mobile only)
 - Uses `ToggleRow` helper component for consistent toggle styling
 - Accessible dialog with custom styling
 - Persists changes via `useSettings()` hook
 
-### use-settings.ts (~70 lines)
+### use-settings.ts (~75 lines)
 
 Settings state management using `useSyncExternalStore`:
 
@@ -133,8 +139,10 @@ Settings state management using `useSyncExternalStore`:
   - `toolbarDefaultExpanded`: boolean
   - `disableContextMenu`: boolean (default: true)
   - `pollInterval`: number in seconds (default: 5, range: 3-300 for 3s-5m)
+  - `hasSeenGestureHints`: boolean (default: false)
+  - `pasteSource`: 'clipboard' | 'tmux' (default: 'clipboard')
 - `updateSetting()` callback to update individual settings
-- Defaults to send-only + collapsed toolbar + context menu disabled + 5s poll interval
+- Defaults to send-only + collapsed toolbar + context menu disabled + 5s poll + clipboard paste
 
 ### use-gestures.ts (~53 lines)
 

--- a/docs/project-overview-pdr.md
+++ b/docs/project-overview-pdr.md
@@ -30,11 +30,14 @@ PWA that wraps ttyd terminals with:
 | Session Management     | Create, switch, delete tmux windows via UI                 |
 | Virtual Keyboard       | Touch-friendly buttons for special keys                    |
 | Keyboard Gestures      | Swipe, long-press, pinch for common shortcuts              |
+| Gesture Hints          | First-time overlay teaching touch gestures (mobile)        |
 | Theme Support          | Light/dark/system theme toggle (in-place switching)        |
 | Font Scaling           | Adjustable terminal font size (6-24px)                     |
 | Fullscreen Mode        | Desktop-only fullscreen terminal view                      |
 | Context Menu Control   | Disable right-click menu on terminal (default: enabled)    |
 | Settings / Preferences | IME behavior, toolbar default, context menu, poll interval |
+| Paste Source Config    | Choose paste source: system clipboard or tmux buffer       |
+| Toast Notifications    | Error feedback for clipboard access issues                 |
 | Persistent Settings    | User preferences saved to localStorage                     |
 | Session Poll Interval  | Configurable sync frequency (3s-5m) to reduce server spam  |
 | Session Cookie Auth    | Prevents double basic auth prompt on mobile                |

--- a/pwa/src/App.tsx
+++ b/pwa/src/App.tsx
@@ -8,11 +8,11 @@ import { KeyboardToolbar } from './components/keyboard-toolbar'
 import { SessionSidebar } from './components/session-sidebar'
 import { SettingsMenu } from './components/settings-menu'
 import { SettingsModal } from './components/settings-modal'
-import { Toast } from './components/toast'
 import {
   TerminalFrame,
   type TerminalFrameHandle,
 } from './components/terminal-frame'
+import { Toast } from './components/toast'
 import { useTheme } from './contexts/theme-context'
 import { useFontSize } from './hooks/use-font-size'
 import { useFullscreen } from './hooks/use-fullscreen'
@@ -27,22 +27,27 @@ import {
   focusTerminal,
   isInCopyMode,
   isTerminalDisconnected,
+  type PasteErrorReason,
+  type PasteResult,
   pasteTmuxBuffer,
   pasteToTerminal,
   scrollTmux,
   sendKeyToTerminal,
   sendTextToTerminal,
   toggleTmuxCopyMode,
-  type PasteErrorReason,
-  type PasteResult,
 } from './utils/terminal-bridge'
 
 // Check if paste result should show an error toast
-const shouldShowPasteError = (result: PasteResult): result is { ok: false; reason: PasteErrorReason } =>
+const shouldShowPasteError = (
+  result: PasteResult,
+): result is { ok: false; reason: PasteErrorReason } =>
   !result.ok && result.reason !== 'empty' && result.reason !== 'no-terminal'
 
 // Error-specific clipboard messages
-const getClipboardErrorMsg = (reason: PasteErrorReason, isLongPress = false): string => {
+const getClipboardErrorMsg = (
+  reason: PasteErrorReason,
+  isLongPress = false,
+): string => {
   switch (reason) {
     case 'not-allowed':
       return isLongPress

--- a/pwa/src/App.tsx
+++ b/pwa/src/App.tsx
@@ -2,11 +2,13 @@ import { Maximize, Menu, Minimize } from 'lucide-react'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { AboutModal } from './components/about-modal'
 import { BottomNavigation } from './components/bottom-navigation'
+import { GestureHintsOverlay } from './components/gesture-hints-overlay'
 import { HelpModal } from './components/help-modal'
 import { KeyboardToolbar } from './components/keyboard-toolbar'
 import { SessionSidebar } from './components/session-sidebar'
 import { SettingsMenu } from './components/settings-menu'
 import { SettingsModal } from './components/settings-modal'
+import { Toast } from './components/toast'
 import {
   TerminalFrame,
   type TerminalFrameHandle,
@@ -31,7 +33,29 @@ import {
   sendKeyToTerminal,
   sendTextToTerminal,
   toggleTmuxCopyMode,
+  type PasteErrorReason,
+  type PasteResult,
 } from './utils/terminal-bridge'
+
+// Check if paste result should show an error toast
+const shouldShowPasteError = (result: PasteResult): result is { ok: false; reason: PasteErrorReason } =>
+  !result.ok && result.reason !== 'empty' && result.reason !== 'no-terminal'
+
+// Error-specific clipboard messages
+const getClipboardErrorMsg = (reason: PasteErrorReason, isLongPress = false): string => {
+  switch (reason) {
+    case 'not-allowed':
+      return isLongPress
+        ? 'Long press paste not supported. Use the Paste button.'
+        : 'Clipboard permission denied. Check browser settings.'
+    case 'not-secure':
+      return 'Clipboard requires HTTPS. Use text input to paste.'
+    case 'not-supported':
+      return 'Clipboard not supported. Use text input to paste.'
+    default:
+      return 'Clipboard access failed. Use text input to paste.'
+  }
+}
 
 export default function App() {
   const terminalRef = useRef<TerminalFrameHandle>(null)
@@ -45,6 +69,8 @@ export default function App() {
   const [aboutOpen, setAboutOpen] = useState(false)
   const [helpOpen, setHelpOpen] = useState(false)
   const [settingsOpen, setSettingsOpen] = useState(false)
+  const [gestureHintsOpen, setGestureHintsOpen] = useState(false)
+  const [toastMessage, setToastMessage] = useState<string | null>(null)
   const { settings, updateSetting } = useSettings()
   const [showTitleTooltip, setShowTitleTooltip] = useState(false)
   const [ctrlActive, setCtrlActive] = useState(false)
@@ -85,7 +111,12 @@ export default function App() {
           scrollTmux(getIframe(), 'up')
         }
       },
-      onLongPress: () => pasteToTerminal(getIframe()),
+      onLongPress: async () => {
+        const result = await pasteToTerminal(getIframe())
+        if (shouldShowPasteError(result)) {
+          setToastMessage(getClipboardErrorMsg(result.reason, true))
+        }
+      },
       onPinchIn: decrease,
       onPinchOut: increase,
     }),
@@ -124,6 +155,23 @@ export default function App() {
     }
   }, [ctrlActive])
 
+  // Show gesture hints on first mobile visit
+  useEffect(() => {
+    if (isMobile && !settings.hasSeenGestureHints) {
+      setGestureHintsOpen(true)
+    }
+  }, [isMobile, settings.hasSeenGestureHints])
+
+  const dismissGestureHints = useCallback(() => {
+    setGestureHintsOpen(false)
+    updateSetting('hasSeenGestureHints', true)
+  }, [updateSetting])
+
+  const showGestureHints = useCallback(() => {
+    setSettingsOpen(false)
+    setGestureHintsOpen(true)
+  }, [])
+
   useGestures(gestureRef, gestureHandlers)
 
   const handleKey = useCallback((key: string) => {
@@ -144,9 +192,12 @@ export default function App() {
     sendKeyToTerminal(getIframe(), key, { shift: true })
   }, [])
 
-  const handleCtrlShiftKey = useCallback((key: string) => {
+  const handleCtrlShiftKey = useCallback(async (key: string) => {
     if (key === 'v') {
-      pasteToTerminal(getIframe())
+      const result = await pasteToTerminal(getIframe())
+      if (shouldShowPasteError(result)) {
+        setToastMessage(getClipboardErrorMsg(result.reason))
+      }
       return
     }
     sendKeyToTerminal(getIframe(), key, { ctrl: true, shift: true })
@@ -160,9 +211,17 @@ export default function App() {
     toggleTmuxCopyMode(getIframe())
   }, [])
 
-  const handleTmuxPaste = useCallback(() => {
-    pasteTmuxBuffer(getIframe())
-  }, [])
+  // Unified paste handler based on pasteSource setting
+  const handlePaste = useCallback(async () => {
+    if (settings.pasteSource === 'tmux') {
+      pasteTmuxBuffer(getIframe())
+    } else {
+      const result = await pasteToTerminal(getIframe())
+      if (shouldShowPasteError(result)) {
+        setToastMessage(getClipboardErrorMsg(result.reason))
+      }
+    }
+  }, [settings.pasteSource])
 
   const handleSendText = useCallback(
     (text: string) => {
@@ -354,7 +413,7 @@ export default function App() {
         onCtrlShiftKey={handleCtrlShiftKey}
         onScroll={handleScroll}
         onTmuxCopy={handleTmuxCopy}
-        onTmuxPaste={handleTmuxPaste}
+        onPaste={handlePaste}
         onToggleKeyboard={toggleKeyboard}
         onSendText={handleSendText}
         ctrlActive={ctrlActive}
@@ -394,7 +453,17 @@ export default function App() {
         onClose={() => setSettingsOpen(false)}
         settings={settings}
         onUpdateSetting={updateSetting}
+        onShowGestureHints={isMobile ? showGestureHints : undefined}
       />
+      {isMobile && (
+        <GestureHintsOverlay
+          isOpen={gestureHintsOpen}
+          onDismiss={dismissGestureHints}
+        />
+      )}
+      {toastMessage && (
+        <Toast message={toastMessage} onClose={() => setToastMessage(null)} />
+      )}
     </div>
   )
 }

--- a/pwa/src/components/gesture-hints-overlay.tsx
+++ b/pwa/src/components/gesture-hints-overlay.tsx
@@ -1,0 +1,88 @@
+import { useEffect, useRef } from 'react'
+
+interface Props {
+  isOpen: boolean
+  onDismiss: () => void
+}
+
+const GESTURE_HINTS = [
+  { icon: '👈', gesture: 'Swipe Left', action: 'Cancel (Ctrl+C)' },
+  { icon: '👉', gesture: 'Swipe Right', action: 'Tab completion' },
+  { icon: '👆👇', gesture: 'Swipe Up/Down', action: 'Scroll in copy mode' },
+  { icon: '👆', gesture: 'Long Press', action: 'Paste clipboard (limited*)' },
+  { icon: '🤏', gesture: 'Pinch In/Out', action: 'Font size' },
+]
+
+export function GestureHintsOverlay({ isOpen, onDismiss }: Props) {
+  const dialogRef = useRef<HTMLDialogElement>(null)
+
+  useEffect(() => {
+    const dialog = dialogRef.current
+    if (!dialog) return
+
+    if (isOpen) {
+      dialog.showModal()
+      const handleCancel = (e: Event) => {
+        e.preventDefault()
+        onDismiss()
+      }
+      dialog.addEventListener('cancel', handleCancel)
+      return () => dialog.removeEventListener('cancel', handleCancel)
+    } else {
+      dialog.close()
+    }
+  }, [isOpen, onDismiss])
+
+  if (!isOpen) return null
+
+  return (
+    <dialog
+      ref={dialogRef}
+      className="fixed inset-0 z-50 m-auto w-[90vw] max-w-sm bg-transparent p-0 backdrop:bg-black/80"
+      aria-labelledby="gesture-hints-title"
+    >
+      <div className="p-6">
+        <h2
+          id="gesture-hints-title"
+          className="text-2xl font-bold text-white text-center mb-2"
+        >
+          Touch Gestures
+        </h2>
+        <p className="text-zinc-400 text-center text-sm mb-6">
+          Control the terminal with gestures
+        </p>
+
+        <div className="space-y-3 mb-8">
+          {GESTURE_HINTS.map((hint) => (
+            <div
+              key={hint.gesture}
+              className="flex items-center gap-4 bg-white/10 rounded-xl px-4 py-3"
+            >
+              <span className="text-2xl w-10 text-center" aria-hidden="true">
+                {hint.icon}
+              </span>
+              <div className="flex-1">
+                <div className="text-white font-medium">{hint.gesture}</div>
+                <div className="text-zinc-400 text-sm">{hint.action}</div>
+              </div>
+            </div>
+          ))}
+        </div>
+
+        <button
+          onClick={onDismiss}
+          className="w-full py-3 bg-blue-500 hover:bg-blue-600 text-white font-medium rounded-xl transition-colors"
+        >
+          Got it
+        </button>
+
+        <p className="text-zinc-500 text-xs text-center mt-4">
+          *Long press paste may not work. Use the Paste button instead.
+        </p>
+        <p className="text-zinc-500 text-xs text-center mt-2">
+          View anytime in Settings &gt; Show Gesture Hints
+        </p>
+      </div>
+    </dialog>
+  )
+}

--- a/pwa/src/components/help-modal.tsx
+++ b/pwa/src/components/help-modal.tsx
@@ -38,7 +38,7 @@ const TOOLBAR_GUIDE: GuideSection[] = [
       { key: 'Shift', desc: 'Toggle Shift modifier (sticky)' },
       { key: '↑↓←→', desc: 'Arrow keys' },
       { key: '⏱ History', desc: 'Toggle tmux copy mode' },
-      { key: '📋 Paste', desc: 'Paste from tmux buffer' },
+      { key: '📋 Paste', desc: 'Paste (source configurable in Settings)' },
       { key: '⇈⇊ Scroll', desc: 'Page up/down in copy mode' },
     ],
   },

--- a/pwa/src/components/keyboard-toolbar.tsx
+++ b/pwa/src/components/keyboard-toolbar.tsx
@@ -35,7 +35,7 @@ interface Props {
   onCtrlShiftKey?: (key: string) => void
   onScroll?: (direction: 'up' | 'down', pages?: boolean) => void
   onTmuxCopy?: () => void
-  onTmuxPaste?: () => void
+  onPaste?: () => void
   onToggleKeyboard?: () => void
   onSendText?: (text: string) => void
   ctrlActive?: boolean
@@ -55,7 +55,7 @@ interface KeyConfig {
   isScroll?: boolean
   scrollDir?: 'up' | 'down'
   isTmuxCopy?: boolean
-  isTmuxPaste?: boolean
+  isPaste?: boolean
   isKeyboardToggle?: boolean
   isImeToggle?: boolean
   isExpandToggle?: boolean
@@ -103,7 +103,7 @@ const UTILITY_KEYS: KeyConfig[] = [
   {
     label: <Clipboard size={ICON_SIZE} />,
     key: 'TmuxPaste',
-    isTmuxPaste: true,
+    isPaste: true,
   },
   {
     label: <ChevronsUp size={ICON_SIZE} />,
@@ -169,7 +169,7 @@ function getKeyButtonBg(
   if (key.isExpandToggle) return 'bg-indigo-200/70 dark:bg-indigo-700/50'
   if (key.isImeToggle) return 'bg-teal-200/70 dark:bg-teal-700/50'
   if (key.isKeyboardToggle) return 'bg-purple-200/70 dark:bg-purple-700/50'
-  if (key.isTmuxCopy || key.isTmuxPaste)
+  if (key.isTmuxCopy || key.isPaste)
     return 'bg-amber-200/70 dark:bg-amber-700/50'
   if (key.isScroll) return 'bg-green-200/70 dark:bg-green-800/50'
   return 'bg-zinc-200/70 dark:bg-zinc-700/70'
@@ -182,7 +182,7 @@ export function KeyboardToolbar({
   onCtrlShiftKey,
   onScroll,
   onTmuxCopy,
-  onTmuxPaste,
+  onPaste,
   onToggleKeyboard,
   onSendText,
   ctrlActive: externalCtrlActive,
@@ -291,7 +291,7 @@ export function KeyboardToolbar({
         isExpandToggle?: boolean
         scrollDir?: 'up' | 'down'
         isTmuxCopy?: boolean
-        isTmuxPaste?: boolean
+        isPaste?: boolean
         isKeyboardToggle?: boolean
         isImeToggle?: boolean
       },
@@ -313,8 +313,8 @@ export function KeyboardToolbar({
         onTmuxCopy()
         return
       }
-      if (opts?.isTmuxPaste && onTmuxPaste) {
-        onTmuxPaste()
+      if (opts?.isPaste && onPaste) {
+        onPaste()
         return
       }
       if (opts?.scrollDir && onScroll) {
@@ -361,7 +361,7 @@ export function KeyboardToolbar({
       onCtrlShiftKey,
       onScroll,
       onTmuxCopy,
-      onTmuxPaste,
+      onPaste,
       onToggleKeyboard,
       toggleImeMode,
       toggleExpanded,
@@ -430,7 +430,7 @@ export function KeyboardToolbar({
               isExpandToggle: keyConfig.isExpandToggle,
               scrollDir: keyConfig.scrollDir,
               isTmuxCopy: keyConfig.isTmuxCopy,
-              isTmuxPaste: keyConfig.isTmuxPaste,
+              isPaste: keyConfig.isPaste,
               isKeyboardToggle: keyConfig.isKeyboardToggle,
               isImeToggle: keyConfig.isImeToggle,
             })

--- a/pwa/src/components/settings-modal.tsx
+++ b/pwa/src/components/settings-modal.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from 'react'
-import type { ImeSendBehavior, Settings } from '../hooks/use-settings'
+import type { ImeSendBehavior, PasteSource, Settings } from '../hooks/use-settings'
 
 interface Props {
   isOpen: boolean
@@ -9,6 +9,7 @@ interface Props {
     key: K,
     value: Settings[K],
   ) => void
+  onShowGestureHints?: () => void
 }
 
 function ToggleRow({
@@ -71,11 +72,29 @@ const IME_SEND_OPTIONS: {
   },
 ]
 
+const PASTE_SOURCE_OPTIONS: {
+  value: PasteSource
+  label: string
+  desc: string
+}[] = [
+  {
+    value: 'clipboard',
+    label: 'System clipboard',
+    desc: 'Paste from device clipboard (Ctrl+Shift+V)',
+  },
+  {
+    value: 'tmux',
+    label: 'tmux buffer',
+    desc: 'Paste from tmux copy mode buffer',
+  },
+]
+
 export function SettingsModal({
   isOpen,
   onClose,
   settings,
   onUpdateSetting,
+  onShowGestureHints,
 }: Props) {
   const dialogRef = useRef<HTMLDialogElement>(null)
 
@@ -155,6 +174,41 @@ export function SettingsModal({
             </div>
           </div>
 
+          <div>
+            <p className="block text-sm font-medium text-zinc-700 dark:text-zinc-300 mb-2">
+              Paste button source
+            </p>
+            <div className="space-y-2">
+              {PASTE_SOURCE_OPTIONS.map((opt) => (
+                <label
+                  key={opt.value}
+                  className={`flex items-start gap-3 p-3 rounded-lg border cursor-pointer transition-colors ${
+                    settings.pasteSource === opt.value
+                      ? 'border-blue-500 bg-blue-50 dark:bg-blue-900/20'
+                      : 'border-zinc-200 dark:border-zinc-600 hover:bg-zinc-50 dark:hover:bg-zinc-700/50'
+                  }`}
+                >
+                  <input
+                    type="radio"
+                    name="pasteSource"
+                    value={opt.value}
+                    checked={settings.pasteSource === opt.value}
+                    onChange={() => onUpdateSetting('pasteSource', opt.value)}
+                    className="mt-0.5 accent-blue-500"
+                  />
+                  <div>
+                    <div className="text-sm font-medium text-zinc-900 dark:text-white">
+                      {opt.label}
+                    </div>
+                    <div className="text-xs text-zinc-500 dark:text-zinc-400">
+                      {opt.desc}
+                    </div>
+                  </div>
+                </label>
+              ))}
+            </div>
+          </div>
+
           <ToggleRow
             label="Toolbar default expanded"
             description="Show all keys when toolbar loads"
@@ -203,6 +257,17 @@ export function SettingsModal({
               ))}
             </select>
           </div>
+
+          {onShowGestureHints && (
+            <div className="pt-2 border-t border-zinc-200 dark:border-zinc-700">
+              <button
+                onClick={onShowGestureHints}
+                className="w-full py-2.5 text-sm font-medium text-blue-600 dark:text-blue-400 hover:bg-blue-50 dark:hover:bg-blue-900/20 rounded-lg transition-colors"
+              >
+                Show Gesture Hints
+              </button>
+            </div>
+          )}
         </div>
       </div>
     </dialog>

--- a/pwa/src/components/settings-modal.tsx
+++ b/pwa/src/components/settings-modal.tsx
@@ -1,5 +1,9 @@
 import { useEffect, useRef } from 'react'
-import type { ImeSendBehavior, PasteSource, Settings } from '../hooks/use-settings'
+import type {
+  ImeSendBehavior,
+  PasteSource,
+  Settings,
+} from '../hooks/use-settings'
 
 interface Props {
   isOpen: boolean

--- a/pwa/src/components/toast.tsx
+++ b/pwa/src/components/toast.tsx
@@ -1,0 +1,22 @@
+import { useEffect } from 'react'
+
+interface Props {
+  message: string
+  onClose: () => void
+  duration?: number
+}
+
+export function Toast({ message, onClose, duration = 4000 }: Props) {
+  useEffect(() => {
+    const timer = setTimeout(onClose, duration)
+    return () => clearTimeout(timer)
+  }, [onClose, duration])
+
+  return (
+    <div className="fixed bottom-24 left-1/2 -translate-x-1/2 z-50 animate-in fade-in slide-in-from-bottom-4 duration-200">
+      <div className="bg-zinc-800 dark:bg-zinc-700 text-white text-sm px-4 py-3 rounded-xl shadow-lg max-w-[85vw]">
+        {message}
+      </div>
+    </div>
+  )
+}

--- a/pwa/src/hooks/use-settings.ts
+++ b/pwa/src/hooks/use-settings.ts
@@ -3,12 +3,15 @@ import { useCallback, useSyncExternalStore } from 'react'
 const STORAGE_KEY = 'termote-settings'
 
 export type ImeSendBehavior = 'send-only' | 'send-enter'
+export type PasteSource = 'clipboard' | 'tmux'
 
 export interface Settings {
   imeSendBehavior: ImeSendBehavior
   toolbarDefaultExpanded: boolean
   disableContextMenu: boolean
   pollInterval: number // seconds between session list refreshes
+  hasSeenGestureHints: boolean // first-time gesture hints overlay
+  pasteSource: PasteSource // paste button source: system clipboard or tmux buffer
 }
 
 const DEFAULTS: Settings = {
@@ -16,6 +19,8 @@ const DEFAULTS: Settings = {
   toolbarDefaultExpanded: false,
   disableContextMenu: true,
   pollInterval: 5,
+  hasSeenGestureHints: false,
+  pasteSource: 'clipboard',
 }
 
 // Listeners for useSyncExternalStore

--- a/pwa/src/utils/terminal-bridge.ts
+++ b/pwa/src/utils/terminal-bridge.ts
@@ -159,15 +159,50 @@ export function blurTerminal(iframe: HTMLIFrameElement | null) {
   }
 }
 
-// Paste text into terminal
-export async function pasteToTerminal(iframe: HTMLIFrameElement | null) {
+export type PasteErrorReason =
+  | 'no-terminal'
+  | 'empty'
+  | 'not-allowed' // User denied or not a valid user gesture
+  | 'not-secure' // Not HTTPS
+  | 'not-supported' // Browser doesn't support clipboard API
+  | 'unknown'
+
+export type PasteResult = { ok: true } | { ok: false; reason: PasteErrorReason }
+
+// Paste text into terminal - returns result with specific error reason
+export async function pasteToTerminal(
+  iframe: HTMLIFrameElement | null,
+): Promise<PasteResult> {
   const term = getTerm(iframe)
-  if (!term) return
+  if (!term) return { ok: false, reason: 'no-terminal' }
+
+  // Check if clipboard API is supported
+  if (!navigator.clipboard?.readText) {
+    return { ok: false, reason: 'not-supported' }
+  }
+
   try {
     const text = await navigator.clipboard.readText()
-    sendData(term, text)
+    if (text) {
+      sendData(term, text)
+      return { ok: true }
+    }
+    return { ok: false, reason: 'empty' }
   } catch (err) {
-    console.warn('Clipboard access denied:', err)
+    const error = err as Error
+    console.warn('Clipboard access failed:', error.name, error.message)
+
+    // Detect specific error types
+    if (error.name === 'NotAllowedError') {
+      return { ok: false, reason: 'not-allowed' }
+    }
+    if (error.name === 'SecurityError' || !window.isSecureContext) {
+      return { ok: false, reason: 'not-secure' }
+    }
+    if (error.name === 'TypeError') {
+      return { ok: false, reason: 'not-supported' }
+    }
+    return { ok: false, reason: 'unknown' }
   }
 }
 

--- a/website/src/content/docs/usage/gestures.mdx
+++ b/website/src/content/docs/usage/gestures.mdx
@@ -7,6 +7,12 @@ import { Aside } from '@astrojs/starlight/components';
 
 Termote supports touch gestures for common terminal operations.
 
+## First-Time Tutorial
+
+On your first mobile visit, a **gesture hints overlay** will appear showing all available gestures. You can:
+- Tap **"Got it"** to dismiss and never see it again
+- Re-open anytime via **Settings → Show Gesture Hints**
+
 ## Gesture Reference
 
 | Gesture     | Action           | Terminal Command |
@@ -33,8 +39,18 @@ Gestures are disabled on desktop where mouse interactions are preferred.
 - Default: 14px
 - Adjust with pinch or toolbar buttons
 
+## Clipboard Paste
+
+Long press paste may not work on all browsers due to clipboard API restrictions:
+- **iOS Safari**: Long press not supported, use the **Paste button** instead
+- **Chrome mobile**: Works with HTTPS
+- **Other browsers**: May require clipboard permission
+
+If paste fails, a toast notification will guide you to use the Paste button or text input.
+
 ## Tips
 
 1. **Quick cancel**: Swipe left to send Ctrl+C when a command hangs
 2. **Tab complete**: Swipe right to autocomplete file/command names
 3. **History**: Swipe up/down to navigate command history
+4. **Paste issues**: If long press doesn't work, use the Paste button in the toolbar

--- a/website/src/content/docs/usage/settings.mdx
+++ b/website/src/content/docs/usage/settings.mdx
@@ -16,6 +16,17 @@ Controls what happens when you tap **Send** in the text input mode (non-Latin in
 
 **Use case**: Set to "Send + Enter" if you want to type a command in Vietnamese/CJK and submit it in one tap.
 
+## Paste Button Source
+
+Controls where the **Paste** button in the toolbar gets content from.
+
+| Option           | Behavior                                        | Default |
+| ---------------- | ----------------------------------------------- | ------- |
+| System clipboard | Paste from device clipboard (Ctrl+Shift+V)      | ✓       |
+| tmux buffer      | Paste from tmux copy mode buffer (Ctrl+B, ])    |         |
+
+**Tip**: Use "System clipboard" for pasting from other apps. Use "tmux buffer" for pasting text copied within tmux.
+
 ## Toolbar Default Expanded
 
 Controls whether the keyboard toolbar starts in expanded or minimal mode when the page loads.
@@ -41,6 +52,12 @@ Controls how often the app syncs the session list from the server. Lower values 
 | Option                            | Default |
 | --------------------------------- | ------- |
 | 3s, 5s, 10s, 15s, 30s, 1m, 2m, 5m | 5s ✓    |
+
+## Show Gesture Hints (Mobile Only)
+
+Re-opens the gesture tutorial overlay that appeared on your first visit. Useful if you want to review available touch gestures.
+
+This button only appears on mobile devices.
 
 ## Persistence
 

--- a/website/src/content/docs/vi/usage/gestures.mdx
+++ b/website/src/content/docs/vi/usage/gestures.mdx
@@ -7,6 +7,12 @@ import { Aside } from '@astrojs/starlight/components';
 
 Termote hỗ trợ cử chỉ cảm ứng cho các thao tác terminal phổ biến.
 
+## Hướng dẫn lần đầu
+
+Khi truy cập lần đầu trên di động, một **overlay hướng dẫn cử chỉ** sẽ hiện ra hiển thị tất cả cử chỉ có sẵn. Bạn có thể:
+- Nhấn **"Got it"** để đóng và không hiện lại
+- Mở lại bất cứ lúc nào qua **Settings → Show Gesture Hints**
+
 ## Tham chiếu cử chỉ
 
 | Cử chỉ     | Hành động      | Lệnh Terminal |
@@ -33,8 +39,18 @@ Cử chỉ bị tắt trên desktop nơi tương tác chuột được ưu tiên
 - Mặc định: 14px
 - Điều chỉnh bằng chụm hoặc nút toolbar
 
+## Dán từ Clipboard
+
+Nhấn giữ để dán có thể không hoạt động trên một số trình duyệt do hạn chế của Clipboard API:
+- **iOS Safari**: Không hỗ trợ nhấn giữ, dùng **nút Paste** thay thế
+- **Chrome di động**: Hoạt động với HTTPS
+- **Trình duyệt khác**: Có thể cần cấp quyền clipboard
+
+Nếu dán thất bại, thông báo toast sẽ hướng dẫn bạn dùng nút Paste hoặc nhập text.
+
 ## Mẹo
 
 1. **Hủy nhanh**: Vuốt trái để gửi Ctrl+C khi lệnh bị treo
 2. **Tab complete**: Vuốt phải để tự động hoàn thành tên file/lệnh
 3. **Lịch sử**: Vuốt lên/xuống để duyệt lịch sử lệnh
+4. **Lỗi dán**: Nếu nhấn giữ không hoạt động, dùng nút Paste trên toolbar

--- a/website/src/content/docs/vi/usage/settings.mdx
+++ b/website/src/content/docs/vi/usage/settings.mdx
@@ -16,6 +16,17 @@ Truy cập cài đặt qua **biểu tượng bánh răng** (⚙) ở header → 
 
 **Trường hợp sử dụng**: Chọn "Send + Enter" nếu bạn muốn gõ lệnh bằng tiếng Việt/CJK và gửi ngay trong một lần nhấn.
 
+## Nguồn nút Paste
+
+Điều khiển nơi nút **Paste** trên toolbar lấy nội dung.
+
+| Tùy chọn         | Hành vi                                        | Mặc định |
+| ---------------- | ---------------------------------------------- | -------- |
+| System clipboard | Dán từ clipboard thiết bị (Ctrl+Shift+V)       | ✓        |
+| tmux buffer      | Dán từ tmux copy mode buffer (Ctrl+B, ])       |          |
+
+**Mẹo**: Dùng "System clipboard" để dán từ các ứng dụng khác. Dùng "tmux buffer" để dán text đã copy trong tmux.
+
 ## Toolbar mặc định mở rộng
 
 Điều khiển toolbar bàn phím bắt đầu ở chế độ mở rộng hay thu gọn khi tải trang.
@@ -41,6 +52,12 @@ Chặn menu ngữ cảnh trình duyệt (nhấn chuột phải / nhấn giữ) t
 | Tùy chọn                          | Mặc định |
 | --------------------------------- | -------- |
 | 3s, 5s, 10s, 15s, 30s, 1m, 2m, 5m | 5s ✓     |
+
+## Hiện hướng dẫn cử chỉ (Chỉ di động)
+
+Mở lại overlay hướng dẫn cử chỉ đã hiện khi bạn truy cập lần đầu. Hữu ích khi bạn muốn xem lại các cử chỉ cảm ứng có sẵn.
+
+Nút này chỉ hiện trên thiết bị di động.
 
 ## Lưu trữ
 


### PR DESCRIPTION
## Summary

- Add first-time gesture hints overlay that shows on first mobile visit
- Add toast notifications for clipboard error feedback with specific messages
- Add configurable paste source setting (system clipboard vs tmux buffer)
- Detect specific clipboard errors (not-allowed, not-secure, not-supported)
- Update settings modal with paste source radio options and "Show Gesture Hints" button

## Features

### Gesture Hints Overlay
- Shows automatically on first mobile visit
- Teaches 5 touch gestures (swipe, long press, pinch)
- Can be re-triggered via Settings > Show Gesture Hints
- Uses `<dialog>` for accessibility (focus trap, ARIA, Escape key)

### Configurable Paste Source
- New setting: "Paste button source" with two options:
  - System clipboard (default) - uses `navigator.clipboard.readText()`
  - tmux buffer - pastes from tmux copy mode
- Single Paste button, behavior changes based on setting

### Toast Notifications
- Shows specific error messages for clipboard failures:
  - "Long press paste not supported. Use the Paste button." (gesture not allowed)
  - "Clipboard permission denied. Check browser settings."
  - "Clipboard requires HTTPS. Use text input to paste."
  - "Clipboard not supported. Use text input to paste."

## Test plan

- [ ] Verify gesture hints overlay shows on first mobile visit
- [ ] Verify "Got it" button dismisses and saves `hasSeenGestureHints`
- [ ] Verify "Show Gesture Hints" button in settings (mobile only)
- [ ] Verify paste source setting changes Paste button behavior
- [ ] Verify toast shows appropriate error on clipboard failure
- [ ] Verify long press paste works on Chrome mobile (HTTPS)
- [ ] Verify long press paste shows "Use Paste button" on iOS Safari