### PR TITLE
feat(cli): add version command

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -177,6 +177,7 @@ Available commands in `termote.sh`:
 - `termote health` — check service health
 - `termote link` — create `/usr/local/bin/termote` symlink
 - `termote unlink` — remove symlink
+- `termote version` — show installed version
 - `termote update` — self-update to latest release
 - `termote update --version X.Y.Z` — pin to specific version
 - `termote update --force` — reinstall current version

--- a/scripts/termote.ps1
+++ b/scripts/termote.ps1
@@ -18,7 +18,7 @@
 [CmdletBinding()]
 param(
     [Parameter(Position = 0)]
-    [ValidateSet("install", "uninstall", "health", "logs", "link", "unlink", "help", "")]
+    [ValidateSet("install", "uninstall", "health", "logs", "link", "unlink", "version", "help", "")]
     [string]$Command,
 
     [Parameter(Position = 1)]
@@ -1086,6 +1086,7 @@ function Show-Help {
     Write-Host "  logs [service]    View logs (ttyd, tmux-api, all, clean)"
     Write-Host "  link              Create 'termote' global command"
     Write-Host "  unlink            Remove global command"
+    Write-Host "  version           Show version"
     Write-Host "  help              Show this help"
     Write-Host ""
     Write-Host "Modes:"
@@ -1144,6 +1145,9 @@ switch ($Command) {
     }
     "unlink" {
         Invoke-Unlink
+    }
+    "version" {
+        Write-Host "Termote v$script:VERSION"
     }
     "help" {
         Show-Help

--- a/scripts/termote.sh
+++ b/scripts/termote.sh
@@ -825,6 +825,7 @@ cmd_help() {
     echo "  logs [service]    View logs (ttyd, tmux-api, all, follow, clean)"
     echo "  link              Create 'termote' symlink in /usr/local/bin"
     echo "  unlink            Remove 'termote' symlink"
+    echo "  version           Show version"
     echo "  help              Show this help"
     echo ""
     echo "Modes:"
@@ -1131,6 +1132,7 @@ case "$CMD" in
     logs)      cmd_logs "$@" ;;
     link)      cmd_link ;;
     unlink)    cmd_unlink ;;
+    version|-v|--version) echo "Termote v$VERSION" ;;
     help|-h|--help) cmd_help ;;
     *)
         error "Unknown command: $CMD"


### PR DESCRIPTION
## Summary
- Add `termote version` command to display installed version
- Support `-v` and `--version` flags on Unix
- Update help text and CLAUDE.md documentation

## Test plan
- [x] `./scripts/termote.sh version` outputs version
- [x] `./scripts/termote.sh -v` outputs version
- [x] `./scripts/termote.sh --version` outputs version
- [ ] Windows: `.\scripts\termote.ps1 version` outputs version