### PR TITLE
docs(website): add Windows support to deployment modes table

### DIFF
--- a/website/src/content/docs/index.mdx
+++ b/website/src/content/docs/index.mdx
@@ -47,7 +47,7 @@ curl -fsSL https://raw.githubusercontent.com/lamngockhuong/termote/main/scripts/
 
 ## Deployment Modes
 
-| Mode      | Description          | Use Case                        | Platform     |
-| --------- | -------------------- | ------------------------------- | ------------ |
-| Container | All-in-one container | Simple deployment, isolated env | macOS, Linux |
-| Native    | All native           | Host tool access (claude, gh)   | macOS, Linux |
+| Mode          | Description               | Use Case                        | Platform              |
+| ------------- | ------------------------- | ------------------------------- | --------------------- |
+| `--container` | Container mode            | Simple deployment, isolated env | macOS, Linux, Windows |
+| `--native`    | All native (no container) | Host tool access (Claude Code)  | macOS, Linux, Windows |

--- a/website/src/content/docs/vi/index.mdx
+++ b/website/src/content/docs/vi/index.mdx
@@ -47,7 +47,7 @@ curl -fsSL https://raw.githubusercontent.com/lamngockhuong/termote/main/scripts/
 
 ## Chế độ triển khai
 
-| Chế độ    | Mô tả                      | Trường hợp sử dụng                     | Nền tảng     |
-| --------- | -------------------------- | -------------------------------------- | ------------ |
-| Container | Container tất-cả-trong-một | Triển khai đơn giản, môi trường cô lập | macOS, Linux |
-| Native    | Tất cả native              | Truy cập công cụ host (claude, gh)     | macOS, Linux |
+| Chế độ        | Mô tả                       | Trường hợp sử dụng                     | Nền tảng              |
+| ------------- | --------------------------- | -------------------------------------- | --------------------- |
+| `--container` | Chế độ container            | Triển khai đơn giản, môi trường cô lập | macOS, Linux, Windows |
+| `--native`    | Native (không dùng container) | Truy cập công cụ host (Claude Code)    | macOS, Linux, Windows |


### PR DESCRIPTION
## Summary
- Add Windows to Platform column in deployment modes table
- Use `--container`/`--native` flag format (matches CLI usage)
- Update descriptions for consistency with CLAUDE.md

## Test plan
- [ ] Verify website builds: `cd website && pnpm build`
- [ ] Check EN homepage renders correctly
- [ ] Check VI homepage renders correctly