### PR TITLE
feat(pwa): replace emoji with lucide icons in help modal

### DIFF
--- a/pwa/src/components/help-modal.tsx
+++ b/pwa/src/components/help-modal.tsx
@@ -1,4 +1,19 @@
-import { useEffect, useRef, useState } from 'react'
+import {
+  ArrowDown,
+  ArrowLeft,
+  ArrowRight,
+  ArrowUp,
+  ChevronsDown,
+  ChevronsUp,
+  Clipboard,
+  CornerDownLeft,
+  Expand,
+  History,
+  Keyboard,
+  Languages,
+  Minimize2,
+} from 'lucide-react'
+import { type ReactNode, useEffect, useRef, useState } from 'react'
 
 interface Props {
   isOpen: boolean
@@ -9,8 +24,10 @@ type TabId = 'gestures' | 'tmux' | 'toolbar'
 
 interface GuideSection {
   title: string
-  items: { key: string; desc: string }[]
+  items: { key: ReactNode; desc: string }[]
 }
+
+const ICON_SIZE = 14
 
 const GESTURES_GUIDE: GuideSection[] = [
   {
@@ -25,21 +42,44 @@ const GESTURES_GUIDE: GuideSection[] = [
   },
 ]
 
+const ExpandCollapseIcon = () => (
+  <span className="inline-flex items-center gap-0.5">
+    <Expand size={ICON_SIZE} />/<Minimize2 size={ICON_SIZE} />
+  </span>
+)
+
+const ArrowKeysIcon = () => (
+  <span className="inline-flex items-center gap-0.5">
+    <ArrowUp size={ICON_SIZE} />
+    <ArrowDown size={ICON_SIZE} />
+    <ArrowLeft size={ICON_SIZE} />
+    <ArrowRight size={ICON_SIZE} />
+  </span>
+)
+
+const ScrollIcon = () => (
+  <span className="inline-flex items-center gap-0.5">
+    <ChevronsUp size={ICON_SIZE} />
+    <ChevronsDown size={ICON_SIZE} />
+  </span>
+)
+
 const TOOLBAR_GUIDE: GuideSection[] = [
   {
     title: 'Toolbar Buttons',
     items: [
-      { key: '⛶/⊟', desc: 'Expand/collapse keyboard' },
-      { key: '⌨️ Keyboard', desc: 'Toggle virtual keyboard' },
+      { key: <ExpandCollapseIcon />, desc: 'Expand/collapse keyboard' },
+      { key: <Keyboard size={ICON_SIZE} />, desc: 'Toggle virtual keyboard' },
+      { key: <Languages size={ICON_SIZE} />, desc: 'Text input mode (IME)' },
       { key: 'Tab', desc: 'Tab key / autocomplete' },
       { key: 'Esc', desc: 'Escape key (clears modifiers if active)' },
-      { key: '↵ Enter', desc: 'Submit command' },
+      { key: <CornerDownLeft size={ICON_SIZE} />, desc: 'Enter / Submit command' },
       { key: 'Ctrl', desc: 'Toggle Ctrl modifier (sticky)' },
       { key: 'Shift', desc: 'Toggle Shift modifier (sticky)' },
-      { key: '↑↓←→', desc: 'Arrow keys' },
-      { key: '⏱ History', desc: 'Toggle tmux copy mode' },
-      { key: '📋 Paste', desc: 'Paste (source configurable in Settings)' },
-      { key: '⇈⇊ Scroll', desc: 'Page up/down in copy mode' },
+      { key: <ArrowKeysIcon />, desc: 'Arrow keys' },
+      { key: <History size={ICON_SIZE} />, desc: 'Toggle tmux copy mode' },
+      { key: <Clipboard size={ICON_SIZE} />, desc: 'Paste (source configurable in Settings)' },
+      { key: <ScrollIcon />, desc: 'Page up/down in copy mode' },
     ],
   },
   {
@@ -208,7 +248,7 @@ export function HelpModal({ isOpen, onClose }: Props) {
                 <div className="bg-zinc-50 dark:bg-zinc-700/30 rounded-lg overflow-hidden">
                   {section.items.map((item, idx) => (
                     <div
-                      key={item.key}
+                      key={idx}
                       className={`flex items-center gap-3 px-3 py-2 ${
                         idx > 0
                           ? 'border-t border-zinc-200/50 dark:border-zinc-600/50'

--- a/pwa/src/components/help-modal.tsx
+++ b/pwa/src/components/help-modal.tsx
@@ -73,12 +73,18 @@ const TOOLBAR_GUIDE: GuideSection[] = [
       { key: <Languages size={ICON_SIZE} />, desc: 'Text input mode (IME)' },
       { key: 'Tab', desc: 'Tab key / autocomplete' },
       { key: 'Esc', desc: 'Escape key (clears modifiers if active)' },
-      { key: <CornerDownLeft size={ICON_SIZE} />, desc: 'Enter / Submit command' },
+      {
+        key: <CornerDownLeft size={ICON_SIZE} />,
+        desc: 'Enter / Submit command',
+      },
       { key: 'Ctrl', desc: 'Toggle Ctrl modifier (sticky)' },
       { key: 'Shift', desc: 'Toggle Shift modifier (sticky)' },
       { key: <ArrowKeysIcon />, desc: 'Arrow keys' },
       { key: <History size={ICON_SIZE} />, desc: 'Toggle tmux copy mode' },
-      { key: <Clipboard size={ICON_SIZE} />, desc: 'Paste (source configurable in Settings)' },
+      {
+        key: <Clipboard size={ICON_SIZE} />,
+        desc: 'Paste (source configurable in Settings)',
+      },
       { key: <ScrollIcon />, desc: 'Page up/down in copy mode' },
     ],
   },
@@ -248,7 +254,7 @@ export function HelpModal({ isOpen, onClose }: Props) {
                 <div className="bg-zinc-50 dark:bg-zinc-700/30 rounded-lg overflow-hidden">
                   {section.items.map((item, idx) => (
                     <div
-                      key={idx}
+                      key={item.desc}
                       className={`flex items-center gap-3 px-3 py-2 ${
                         idx > 0
                           ? 'border-t border-zinc-200/50 dark:border-zinc-600/50'

--- a/website/src/content/docs/usage/keyboard.mdx
+++ b/website/src/content/docs/usage/keyboard.mdx
@@ -117,7 +117,7 @@ Container mode has this pre-configured.
 
 ## Text Input Mode (Non-Latin)
 
-Tap the **Languages** button (🌐) to switch to text input mode. This is designed for typing non-Latin scripts (Vietnamese, Chinese, Japanese, Korean, Thai, etc.) that require IME composition.
+Tap the **Languages icon** to switch to text input mode. This is designed for typing non-Latin scripts (Vietnamese, Chinese, Japanese, Korean, Thai, etc.) that require IME composition.
 
 | Action    | Result                                                                        |
 | --------- | ----------------------------------------------------------------------------- |

--- a/website/src/content/docs/vi/usage/keyboard.mdx
+++ b/website/src/content/docs/vi/usage/keyboard.mdx
@@ -117,7 +117,7 @@ Container mode đã được cấu hình sẵn.
 
 ## Chế độ nhập text (ngoài Latin)
 
-Nhấn nút **Languages** (🌐) để chuyển sang chế độ nhập text. Chế độ này dành cho gõ các ngôn ngữ ngoài Latin (tiếng Việt, Trung, Nhật, Hàn, Thái, v.v.) cần IME.
+Nhấn **Languages icon** để chuyển sang chế độ nhập text. Chế độ này dành cho gõ các ngôn ngữ ngoài Latin (tiếng Việt, Trung, Nhật, Hàn, Thái, v.v.) cần IME.
 
 | Hành động | Kết quả                                                                       |
 | --------- | ----------------------------------------------------------------------------- |


### PR DESCRIPTION
## Summary
- Replace emoji symbols (⌨️, 📋, ⏱, etc.) with lucide-react icons in help modal toolbar guide
- Add Languages icon entry for IME mode
- Update docs to use text description for Languages icon (consistency with Copy/Paste icon pattern)

## Test plan
- [ ] Open PWA → tap "?" button → navigate to Toolbar tab
- [ ] Verify icons match actual keyboard toolbar appearance
- [ ] Check both light and dark mode rendering