### PR TITLE
docs: sync usage guide with current toolbar implementation

### DIFF
--- a/pwa/src/components/help-modal.tsx
+++ b/pwa/src/components/help-modal.tsx
@@ -6,6 +6,7 @@ import {
   ChevronsDown,
   ChevronsUp,
   Clipboard,
+  Clock,
   CornerDownLeft,
   Expand,
   History,
@@ -68,9 +69,9 @@ const TOOLBAR_GUIDE: GuideSection[] = [
   {
     title: 'Toolbar Buttons',
     items: [
-      { key: <ExpandCollapseIcon />, desc: 'Expand/collapse keyboard' },
       { key: <Keyboard size={ICON_SIZE} />, desc: 'Toggle virtual keyboard' },
       { key: <Languages size={ICON_SIZE} />, desc: 'Text input mode (IME)' },
+      { key: <Clock size={ICON_SIZE} />, desc: 'Command history search' },
       { key: 'Tab', desc: 'Tab key / autocomplete' },
       { key: 'Esc', desc: 'Escape key (clears modifiers if active)' },
       {
@@ -80,6 +81,7 @@ const TOOLBAR_GUIDE: GuideSection[] = [
       { key: 'Ctrl', desc: 'Toggle Ctrl modifier (sticky)' },
       { key: 'Shift', desc: 'Toggle Shift modifier (sticky)' },
       { key: <ArrowKeysIcon />, desc: 'Arrow keys' },
+      { key: <ExpandCollapseIcon />, desc: 'Expand/collapse keyboard' },
       { key: <History size={ICON_SIZE} />, desc: 'Toggle tmux copy mode' },
       {
         key: <Clipboard size={ICON_SIZE} />,
@@ -103,9 +105,10 @@ const TOOLBAR_GUIDE: GuideSection[] = [
   {
     title: 'Ctrl+Shift Combos',
     items: [
-      { key: '^⇧V', desc: 'Paste from clipboard' },
       { key: '^⇧C', desc: 'Copy (terminal)' },
+      { key: '^⇧V', desc: 'Paste from clipboard' },
       { key: '^⇧Z', desc: 'Redo' },
+      { key: '^⇧X', desc: 'Cut' },
     ],
   },
   {

--- a/website/src/content/docs/usage/keyboard.mdx
+++ b/website/src/content/docs/usage/keyboard.mdx
@@ -9,12 +9,13 @@ The keyboard toolbar provides touch-friendly buttons for common terminal keys. I
 
 ## Toolbar Features
 
-| Feature        | Icon  | Description                                    |
-| -------------- | ----- | ---------------------------------------------- |
-| Minimal mode   | —     | Default, shows essential keys                  |
-| Expanded mode  | ↑     | Tap to show all keys (Home, End, Delete, etc.) |
-| Command history| 🕐    | View and search recent commands (see below)    |
-| Text input     | 🌐    | Switch to IME mode for non-Latin scripts       |
+| Feature         | Icon    | Description                                    |
+| --------------- | ------- | ---------------------------------------------- |
+| Minimal mode    | —       | Default, shows essential keys                  |
+| Expanded mode   | Expand  | Tap to show all keys (Home, End, Delete, etc.) |
+| Keyboard toggle | ⌨️      | Show/hide the virtual keyboard                 |
+| Command history | 🕐      | View and search recent commands (see below)    |
+| Text input      | 🌐      | Switch to IME mode for non-Latin scripts       |
 
 ## Modes
 
@@ -81,8 +82,8 @@ The keyboard toolbar provides touch-friendly buttons for common terminal keys. I
 | ---------- | ---------------------------- |
 | Copy icon  | Toggle tmux copy mode        |
 | Paste icon | Paste from tmux buffer       |
-| PgUp       | Scroll up (tmux)             |
-| PgDn       | Scroll down (tmux)           |
+| ⇈          | Scroll up (tmux)             |
+| ⇊          | Scroll down (tmux)           |
 
 ### tmux Copy/Paste Workflow
 

--- a/website/src/content/docs/usage/settings.mdx
+++ b/website/src/content/docs/usage/settings.mdx
@@ -51,8 +51,8 @@ Displays a horizontal tab bar at the top for quick session switching on desktop.
 
 | Option | Behavior                              | Default |
 | ------ | ------------------------------------- | ------- |
-| On     | Show session tabs in header            |         |
-| Off    | Hide tabs, use sidebar only           | ✓       |
+| On     | Show session tabs in header           | ✓       |
+| Off    | Hide tabs, use sidebar only           |         |
 
 This setting only appears on desktop devices.
 


### PR DESCRIPTION
## Summary
- Reorder help modal toolbar items to match actual button layout order
- Add missing Clock (command history), Keyboard toggle, and Ctrl+Shift+X (Cut) to help modal
- Fix icon labels (Expand, scroll chevrons) and Show Session Tabs default in website docs

## Test plan
- [ ] Open PWA → help modal → Toolbar tab → verify button order matches actual toolbar
- [ ] Verify all toolbar buttons are listed in the guide
- [ ] Check website docs render correctly for keyboard and settings pages