### PR TITLE
docs: add README translations for 9 languages

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -1,0 +1,453 @@
+<p align="center">
+  <img src="pwa/public/banner-readme.svg" alt="Termote" width="600" />
+</p>
+
+<p align="center">
+  <a href="https://github.com/lamngockhuong/termote/releases"><img src="https://img.shields.io/github/v/release/lamngockhuong/termote?style=flat-square&color=blue" alt="Release" /></a>
+  <a href="https://github.com/lamngockhuong/termote/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/lamngockhuong/termote/ci.yml?branch=main&style=flat-square&label=CI" alt="CI" /></a>
+  <a href="https://github.com/lamngockhuong/termote/blob/main/LICENSE"><img src="https://img.shields.io/github/license/lamngockhuong/termote?style=flat-square" alt="License" /></a>
+  <a href="https://ghcr.io/lamngockhuong/termote"><img src="https://img.shields.io/badge/GHCR-termote-blue?style=flat-square&logo=github" alt="GHCR" /></a>
+  <a href="https://hub.docker.com/r/lamngockhuong/termote"><img src="https://img.shields.io/docker/pulls/lamngockhuong/termote?style=flat-square&logo=docker" alt="Docker Pulls" /></a>
+</p>
+
+<p align="center">
+  <img src="https://img.shields.io/badge/Go-1.21-00ADD8?style=flat-square&logo=go&logoColor=white" alt="Go" />
+  <img src="https://img.shields.io/badge/React-19-61DAFB?style=flat-square&logo=react&logoColor=black" alt="React" />
+  <img src="https://img.shields.io/badge/TypeScript-5.9-3178C6?style=flat-square&logo=typescript&logoColor=white" alt="TypeScript" />
+  <img src="https://img.shields.io/badge/PWA-ready-5A0FC8?style=flat-square&logo=pwa&logoColor=white" alt="PWA" />
+</p>
+
+<p align="center">
+  <a href="https://launch.j2team.dev/products/termote?utm_source=badge-launched&utm_medium=badge&utm_campaign=badge-termote" target="_blank" rel="noopener noreferrer"><img src="https://launch.j2team.dev/badge/termote/dark" alt="Termote - Launched on J2TEAM Launch" width="170" height="36" loading="lazy" /></a>
+  &nbsp;
+  <a href="https://unikorn.vn/p/termote?ref=embed-termote" target="_blank"><img src="https://unikorn.vn/api/widgets/badge/termote?theme=dark" alt="Termote trên Unikorn.vn" width="170" height="42" /></a>
+</p>
+
+CLI-Tools (Claude Code, GitHub Copilot, jedes Terminal) per PWA von Mobilgeräten/Desktop fernsteuern.
+
+> **Termote** = Terminal + Remote
+>
+> 🇬🇧 [English](README.md) | 🇻🇳 [Tiếng Việt](README.vi.md) | 🇨🇳 [简体中文](README.zh-CN.md) | 🇯🇵 [日本語](README.ja.md) | 🇰🇷 [한국어](README.ko.md) | 🇪🇸 [Español](README.es.md) | 🇧🇷 [Português (BR)](README.pt-BR.md) | 🇫🇷 [Français](README.fr.md) | 🇷🇺 [Русский](README.ru.md) | 🇮🇩 [Bahasa Indonesia](README.id.md)
+
+## Funktionen
+
+- **Session-Wechsel**: Mehrere tmux-Sessions mit Erstellen/Bearbeiten/Löschen
+- **Session-Tabs**: Horizontale Tab-Leiste zum schnellen Fensterwechsel
+- **Mobilfreundlich**: Virtuelle Tastatur-Toolbar (Tab/Ctrl/Shift/Pfeiltasten, erweiterbar)
+- **Gestenunterstützung**: Wischen für Ctrl+C, Tab, Verlaufsnavigation
+- **Befehlsverlauf**: Zuvor gesendete Befehle mit Suche abrufen
+- **Schnellaktionen**: Schwebendes Menü für häufige Operationen (clear, cancel, exit)
+- **Verbindungsanzeige**: Echtzeit-Serverstatus mit automatischer Trennungserkennung
+- **Update-Prüfung**: Automatische Benachrichtigung über neue Versionen von GitHub Releases
+- **PWA**: Auf dem Homescreen installierbar, offline-fähig
+- **Persistente Sessions**: tmux hält Sessions am Leben
+- **Einklappbare Seitenleiste**: Desktop-Oberfläche mit ein-/ausschaltbarer Session-Seitenleiste
+- **Vollbildmodus**: Immersives Terminal-Erlebnis
+- **Konfigurationsspeicherung**: Automatische Speicherung der Installationseinstellungen mit AES-256-verschlüsseltem Passwort
+
+## Screenshots
+
+<p align="center">
+  <img src="docs/images/screenshots/mobile-terminal.png" alt="Mobile Terminal" width="280" />
+  &nbsp;&nbsp;
+  <img src="docs/images/screenshots/mobile-sidebar.png" alt="Session Sidebar" width="280" />
+</p>
+
+## Architektur
+
+```mermaid
+flowchart TB
+    subgraph Client["Client (Mobil/Desktop)"]
+        PWA["PWA - React + TypeScript"]
+        Gestures["Gestensteuerung"]
+        Keyboard["Virtuelle Tastatur"]
+    end
+
+    subgraph Server["tmux-api Server :7680"]
+        Static["Statische Dateien"]
+        Proxy["WebSocket Proxy"]
+        API["REST API /api/tmux/*"]
+        Auth["Basic Auth"]
+    end
+
+    subgraph Backend["Backend-Dienste"]
+        ttyd["ttyd :7681"]
+        tmux["tmux"]
+        Shell["Shell"]
+        Tools["CLI Tools"]
+    end
+
+    Gestures --> PWA
+    Keyboard --> PWA
+    PWA --> Static
+    PWA <--> Proxy
+    PWA --> API
+    Auth -.-> Static & Proxy & API
+    Proxy <--> ttyd
+    API --> tmux
+    ttyd --> tmux --> Shell --> Tools
+```
+
+## Schnellstart
+
+> 📖 **Neu bei Termote?** Schau dir die [Erste-Schritte-Anleitung](docs/getting-started.md) für eine vollständige Anleitung mit Beispielen an.
+
+```bash
+./scripts/termote.sh                   # Interaktives Menü
+./scripts/termote.sh install container # Container-Modus (docker/podman)
+./scripts/termote.sh install native    # Native-Modus (Host-Tools)
+./scripts/termote.sh link              # Globalen Befehl 'termote' erstellen
+make test                              # Tests ausführen
+```
+
+> Nach `link` kann `termote` überall verwendet werden: `termote health`, `termote install native --lan`
+>
+> **Tipp**: Installiere [gum](https://github.com/charmbracelet/gum) für verbesserte interaktive Menüs (optional, Bash-Fallback verfügbar)
+
+## Installation
+
+### Einzeiler (empfohlen)
+
+**macOS/Linux:**
+
+```bash
+# Herunterladen und vor der Installation fragen (Standard: Native-Modus)
+curl -fsSL https://raw.githubusercontent.com/lamngockhuong/termote/main/scripts/get.sh | bash
+
+# Automatisch ohne Nachfrage installieren
+curl -fsSL .../get.sh | bash -s -- --yes
+
+# Nur herunterladen (nicht installieren)
+curl -fsSL .../get.sh | bash -s -- --download-only
+
+# Automatisch mit gespeicherter Konfiguration aktualisieren
+curl -fsSL .../get.sh | bash -s -- --update
+
+# Bestimmte Version installieren
+curl -fsSL .../get.sh | bash -s -- --version 0.0.4
+
+# Mit explizitem Modus und Optionen
+curl -fsSL .../get.sh | bash -s -- --yes --container --lan
+curl -fsSL .../get.sh | bash -s -- --yes --native --tailscale myhost
+
+# Neues Passwort erzwingen (gespeicherte Konfiguration ignorieren)
+curl -fsSL .../get.sh | bash -s -- --yes --container --fresh
+```
+
+**Windows (PowerShell):**
+
+> **Hinweis:** Falls die Skriptausführung auf Ihrem System deaktiviert ist, führen Sie zuerst Folgendes aus:
+>
+> ```powershell
+> Set-ExecutionPolicy -Scope CurrentUser -ExecutionPolicy RemoteSigned
+> ```
+
+```powershell
+# Herunterladen und vor der Installation fragen (Standard: Native-Modus)
+irm https://raw.githubusercontent.com/lamngockhuong/termote/main/scripts/get.ps1 | iex
+
+# Automatisch ohne Nachfrage installieren
+$env:TERMOTE_AUTO_YES = "true"; irm .../get.ps1 | iex
+
+# Mit explizitem Modus
+$env:TERMOTE_MODE = "container"; irm .../get.ps1 | iex
+
+# Automatisch mit gespeicherter Konfiguration aktualisieren
+$env:TERMOTE_UPDATE = "true"; irm .../get.ps1 | iex
+```
+
+### Docker
+
+```bash
+# Alles-in-einem (Zugangsdaten werden automatisch generiert, Logs prüfen: docker logs termote)
+docker run -d --name termote -p 7680:7680 ghcr.io/lamngockhuong/termote:latest
+
+# Mit benutzerdefinierten Zugangsdaten
+docker run -d --name termote -p 7680:7680 \
+  -e TERMOTE_USER=admin -e TERMOTE_PASS=secret \
+  ghcr.io/lamngockhuong/termote:latest
+
+# Ohne Authentifizierung (nur für lokale Entwicklung)
+docker run -d --name termote -p 7680:7680 \
+  -e NO_AUTH=true \
+  ghcr.io/lamngockhuong/termote:latest
+
+# Mit Volume für Persistenz
+docker run -d --name termote -p 7680:7680 \
+  -v termote-data:/home/termote \
+  ghcr.io/lamngockhuong/termote:latest
+
+# Benutzerdefiniertes Workspace-Verzeichnis einbinden
+docker run -d --name termote -p 7680:7680 \
+  -v ~/projects:/workspace \
+  ghcr.io/lamngockhuong/termote:latest
+
+# Mit Tailscale HTTPS (erfordert Tailscale auf dem Host)
+docker run -d --name termote -p 7680:7680 \
+  -e TERMOTE_USER=admin -e TERMOTE_PASS=secret \
+  ghcr.io/lamngockhuong/termote:latest
+sudo tailscale serve --bg --https=443 http://127.0.0.1:7680
+# Zugriff unter: https://your-hostname.tailnet-name.ts.net
+```
+
+### Vom Release
+
+```bash
+# Neuestes Release herunterladen
+VERSION=$(curl -s https://api.github.com/repos/lamngockhuong/termote/releases/latest | grep tag_name | cut -d '"' -f4)
+wget https://github.com/lamngockhuong/termote/releases/download/${VERSION}/termote-${VERSION}.tar.gz
+tar xzf termote-${VERSION}.tar.gz
+cd termote-${VERSION#v}
+
+# Installieren (interaktives Menü oder mit Modus)
+./scripts/termote.sh install
+./scripts/termote.sh install container
+```
+
+### Vom Quellcode
+
+```bash
+git clone https://github.com/lamngockhuong/termote.git
+cd termote
+./scripts/termote.sh install container
+```
+
+> **Hinweis**: `termote.sh` ist das einheitliche CLI mit Unterstützung für `install` (baut aus Quellcode, verwendet vorgefertigte Artefakte wenn verfügbar), `uninstall` und `health`.
+
+## Bereitstellungsmodi
+
+```mermaid
+flowchart LR
+    subgraph Container["Container-Modus"]
+        direction TB
+        C1["Docker/Podman"] --> C2["tmux-api :7680"] --> C3["ttyd :7681"] --> C4["tmux"]
+    end
+
+    subgraph Native["Native-Modus"]
+        direction TB
+        N1["Hostsystem"] --> N2["tmux-api :7680"] --> N3["ttyd :7681"] --> N4["tmux + Host-Tools"]
+    end
+
+    User["Benutzer"] --> Container & Native
+```
+
+| Modus         | Beschreibung    | Anwendungsfall                           | Plattform    |
+| ------------- | --------------- | ---------------------------------------- | ------------ |
+| `--container` | Container-Modus | Einfache Bereitstellung, isolierte Umgebung | macOS, Linux |
+| `--native`    | Alles nativ     | Zugriff auf Host-Tools (claude, gh)      | macOS, Linux |
+
+### Optionen
+
+| Flag                        | Beschreibung                                              |
+| --------------------------- | --------------------------------------------------------- |
+| `--lan`                     | Im LAN freigeben (Standard: nur localhost)                |
+| `--tailscale <host[:port]>` | Tailscale HTTPS aktivieren                                |
+| `--no-auth`                 | Basis-Authentifizierung deaktivieren                      |
+| `--port <port>`             | Host-Port (Standard: 7680, Windows: 7690)                 |
+| `--fresh`                   | Neues Passwort erzwingen (gespeicherte Konfig. ignorieren) |
+| `--update`                  | Automatisch mit gespeicherter Konfig. aktualisieren       |
+| `--version <ver>`           | Bestimmte Version installieren (mit oder ohne `v`)        |
+
+| Umgebungsvariable | Beschreibung                                             |
+| ----------------- | -------------------------------------------------------- |
+| `WORKSPACE`       | Host-Verzeichnis zum Einbinden (Standard: `./workspace`) |
+| `TERMOTE_USER`    | Benutzername für Authentifizierung (Standard: automatisch generiert) |
+| `TERMOTE_PASS`    | Passwort für Authentifizierung (Standard: automatisch generiert) |
+| `NO_AUTH`         | Auf `true` setzen, um Authentifizierung zu deaktivieren  |
+
+### Container-Modus (empfohlen für Einfachheit)
+
+Skripte erkennen automatisch `podman` oder `docker` -- beide funktionieren identisch.
+
+```bash
+./scripts/termote.sh install container             # localhost mit Basic Auth
+./scripts/termote.sh install container --no-auth   # localhost ohne Auth
+./scripts/termote.sh install container --lan       # LAN-Zugriff
+# Zugriff: http://localhost:7680
+
+# Benutzerdefiniertes Workspace-Verzeichnis (wird als /workspace im Container eingebunden)
+WORKSPACE=~/projects ./scripts/termote.sh install container
+WORKSPACE=/path/to/code make install-container
+```
+
+> **Sicherheitshinweis**: Vermeiden Sie es, `$HOME` direkt einzubinden -- sensible Verzeichnisse wie `.ssh`, `.gnupg` wären im Container zugänglich. Binden Sie stattdessen spezifische Projektverzeichnisse ein.
+
+### Native (empfohlen für Host-Binary-Zugriff)
+
+Verwenden, wenn Zugriff auf Host-Binaries benötigt wird (claude, git, usw.):
+
+```bash
+# Linux
+sudo apt install ttyd tmux
+# Oder: sudo snap install ttyd
+./scripts/termote.sh install native
+
+# macOS
+brew install ttyd tmux go
+./scripts/termote.sh install native
+# Zugriff: http://localhost:7680
+```
+
+### Mit Tailscale HTTPS (alle Modi)
+
+Verwendet `tailscale serve` für automatisches HTTPS (keine manuelle Zertifikatsverwaltung):
+
+```bash
+# Nur Tailscale (Standard-Port 443)
+./scripts/termote.sh install container --tailscale myhost.ts.net
+
+# Benutzerdefinierter Port
+./scripts/termote.sh install native --tailscale myhost.ts.net:8765
+
+# Tailscale + LAN-Zugriff
+./scripts/termote.sh install container --tailscale myhost.ts.net --lan
+
+# Zugriff: https://myhost.ts.net (oder :8765 für benutzerdefinierten Port)
+```
+
+### Deinstallation
+
+```bash
+./scripts/termote.sh uninstall container   # Container-Modus
+./scripts/termote.sh uninstall native      # Native-Modus
+./scripts/termote.sh uninstall all         # Alles
+```
+
+### Aktualisierung
+
+```bash
+# Option 1: Automatisch mit gespeicherter Konfiguration aktualisieren
+curl -fsSL .../get.sh | bash -s -- --update
+
+# Option 2: Einzeiler erneut ausführen (vergleicht Versionen, fragt vor Installation)
+curl -fsSL .../get.sh | bash
+
+# Option 3: Manuell aktualisieren
+./scripts/termote.sh uninstall [container|native]
+git pull origin main                    # Falls vom Quellcode installiert
+./scripts/termote.sh install [container|native] [--lan] [--tailscale ...]
+```
+
+## Plattformunterstützung
+
+| Plattform | Container          | Native             | CLI-Skript  |
+| --------- | ------------------ | ------------------ | ----------- |
+| Linux     | ✓                  | ✓                  | termote.sh  |
+| macOS     | ✓                  | ✓                  | termote.sh  |
+| Windows   | ⚠️ (experimentell)  | ⚠️ (experimentell)  | termote.ps1 |
+
+> **⚠️ Windows-Unterstützung (Experimentell)**: Die Windows-Unterstützung befindet sich derzeit in einem frühen Stadium und erfordert weitere Tests. Der Container-Modus erfordert Docker Desktop, der Native-Modus erfordert psmux. Bitte melden Sie Probleme auf GitHub.
+
+### Windows Native-Modus
+
+Der Windows Native-Modus verwendet [psmux](https://github.com/psmux/psmux) (tmux-kompatibler Terminal-Multiplexer für Windows):
+
+```powershell
+# psmux installieren
+winget install psmux
+
+# Termote ausführen
+.\scripts\termote.ps1 install native
+.\scripts\termote.ps1 install container  # Oder Container-Modus mit Docker Desktop
+```
+
+## Mobile Nutzung
+
+| Aktion            | Geste               |
+| ----------------- | -------------------- |
+| Abbrechen/Unterbrechen | Nach links wischen (Ctrl+C) |
+| Tab-Vervollständigung | Nach rechts wischen  |
+| Verlauf hoch      | Nach oben wischen    |
+| Verlauf runter    | Nach unten wischen   |
+| Einfügen          | Lange drücken        |
+| Schriftgröße      | Zusammen-/Auseinanderziehen |
+
+Die virtuelle Toolbar bietet: Tab, Esc, Ctrl, Shift, Pfeiltasten und gängige Tastenkombinationen. Unterstützt Ctrl+Shift-Kombinationen (Einfügen, Kopieren). Wechsel zwischen minimal und erweitert für zusätzliche Tasten (Home, End, Delete, usw.).
+
+## Projektstruktur
+
+```
+termote/
+├── Makefile                # Build-/Test-/Deploy-Befehle
+├── Dockerfile              # Docker-Modus (tmux-api + ttyd)
+├── docker-compose.yml
+├── entrypoint.sh           # Docker-Entrypoint
+├── docs/                   # Dokumentation
+│   └── images/screenshots/ # App-Screenshots
+├── pwa/                    # React PWA
+│   └── src/
+│       ├── components/
+│       ├── contexts/
+│       ├── hooks/
+│       ├── types/
+│       └── utils/
+├── tmux-api/               # Go-Server
+│   ├── main.go             # Einstiegspunkt
+│   ├── serve.go            # Server (PWA, Proxy, Auth)
+│   └── tmux.go             # tmux API-Handler
+├── scripts/
+│   ├── termote.sh          # Unix CLI (install/uninstall/health)
+│   ├── termote.ps1         # Windows PowerShell CLI
+│   ├── get.sh              # Unix Online-Installer (curl | bash)
+│   └── get.ps1             # Windows Online-Installer (irm | iex)
+├── tests/                  # Testsuite
+│   ├── test-termote.sh
+│   ├── test-termote.ps1    # Windows-Tests
+│   ├── test-get.sh
+│   └── test-entrypoints.sh
+└── website/                # Astro Starlight Docs-Seite
+    └── src/content/docs/   # MDX-Dokumentation
+```
+
+## Entwicklung
+
+```bash
+make build          # PWA und tmux-api bauen
+make test           # Alle Tests ausführen
+make health         # Service-Health prüfen
+make clean          # Container stoppen
+
+# E2E-Tests (erfordert laufenden Server)
+./scripts/termote.sh install container  # Zuerst Server starten
+cd pwa && pnpm test:e2e       # Playwright-Tests ausführen
+cd pwa && pnpm test:e2e:ui    # Mit UI-Debugger ausführen
+```
+
+**Manuelles Testen:** Siehe [Selbsttest-Checkliste](docs/self-test-checklist.md)
+
+## Fehlerbehebung
+
+### Session bleibt nicht erhalten
+
+- tmux prüfen: `tmux ls`
+- Sicherstellen, dass ttyd das Flag `-A` verwendet (attach-or-create)
+
+### WebSocket-Fehler
+
+- tmux-api-Logs prüfen: `docker logs termote`
+- Sicherstellen, dass ttyd auf Port 7681 läuft
+
+### Probleme mit der mobilen Tastatur
+
+- Sicherstellen, dass das Viewport-Meta-Tag vorhanden ist
+- Auf einem echten Gerät testen, nicht im Emulator
+
+### Native-Modus: Prozesse starten nicht
+
+```bash
+ps aux | grep ttyd         # Prüfen, ob ttyd läuft
+ps aux | grep tmux-api     # Prüfen, ob tmux-api läuft
+lsof -i :7680              # Sicherstellen, dass der Port belegt ist
+```
+
+## Sicherheitshinweise
+
+- **Standard: nur localhost** - nicht im LAN erreichbar, es sei denn das Flag `--lan` wird verwendet
+- **Basic Auth standardmäßig aktiviert** - `--no-auth` verwenden, um für lokale Entwicklung zu deaktivieren
+- **Integrierter Brute-Force-Schutz** - Rate-Limiting (5 Versuche/Min. pro IP)
+- HTTPS (Tailscale) für Produktion verwenden
+- Auf vertrauenswürdige Netzwerke/VPN beschränken
+
+## Lizenz
+
+MIT

--- a/README.es.md
+++ b/README.es.md
@@ -1,0 +1,453 @@
+<p align="center">
+  <img src="pwa/public/banner-readme.svg" alt="Termote" width="600" />
+</p>
+
+<p align="center">
+  <a href="https://github.com/lamngockhuong/termote/releases"><img src="https://img.shields.io/github/v/release/lamngockhuong/termote?style=flat-square&color=blue" alt="Release" /></a>
+  <a href="https://github.com/lamngockhuong/termote/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/lamngockhuong/termote/ci.yml?branch=main&style=flat-square&label=CI" alt="CI" /></a>
+  <a href="https://github.com/lamngockhuong/termote/blob/main/LICENSE"><img src="https://img.shields.io/github/license/lamngockhuong/termote?style=flat-square" alt="License" /></a>
+  <a href="https://ghcr.io/lamngockhuong/termote"><img src="https://img.shields.io/badge/GHCR-termote-blue?style=flat-square&logo=github" alt="GHCR" /></a>
+  <a href="https://hub.docker.com/r/lamngockhuong/termote"><img src="https://img.shields.io/docker/pulls/lamngockhuong/termote?style=flat-square&logo=docker" alt="Docker Pulls" /></a>
+</p>
+
+<p align="center">
+  <img src="https://img.shields.io/badge/Go-1.21-00ADD8?style=flat-square&logo=go&logoColor=white" alt="Go" />
+  <img src="https://img.shields.io/badge/React-19-61DAFB?style=flat-square&logo=react&logoColor=black" alt="React" />
+  <img src="https://img.shields.io/badge/TypeScript-5.9-3178C6?style=flat-square&logo=typescript&logoColor=white" alt="TypeScript" />
+  <img src="https://img.shields.io/badge/PWA-ready-5A0FC8?style=flat-square&logo=pwa&logoColor=white" alt="PWA" />
+</p>
+
+<p align="center">
+  <a href="https://launch.j2team.dev/products/termote?utm_source=badge-launched&utm_medium=badge&utm_campaign=badge-termote" target="_blank" rel="noopener noreferrer"><img src="https://launch.j2team.dev/badge/termote/dark" alt="Termote - Launched on J2TEAM Launch" width="170" height="36" loading="lazy" /></a>
+  &nbsp;
+  <a href="https://unikorn.vn/p/termote?ref=embed-termote" target="_blank"><img src="https://unikorn.vn/api/widgets/badge/termote?theme=dark" alt="Termote trên Unikorn.vn" width="170" height="42" /></a>
+</p>
+
+Controla remotamente herramientas CLI (Claude Code, GitHub Copilot, cualquier terminal) desde movil/escritorio via PWA.
+
+> **Termote** = Terminal + Remote
+>
+> 🇬🇧 [English](README.md) | 🇻🇳 [Tiếng Việt](README.vi.md) | 🇨🇳 [简体中文](README.zh-CN.md) | 🇯🇵 [日本語](README.ja.md) | 🇰🇷 [한국어](README.ko.md) | 🇧🇷 [Português (BR)](README.pt-BR.md) | 🇫🇷 [Français](README.fr.md) | 🇩🇪 [Deutsch](README.de.md) | 🇷🇺 [Русский](README.ru.md) | 🇮🇩 [Bahasa Indonesia](README.id.md)
+
+## Caracteristicas
+
+- **Cambio de sesiones**: Multiples sesiones tmux con crear/editar/eliminar
+- **Pestanas de sesiones**: Barra de pestanas horizontal para cambiar rapidamente entre ventanas
+- **Optimizado para movil**: Teclado virtual (Tab/Ctrl/Shift/flechas, expandible)
+- **Soporte de gestos**: Deslizar para Ctrl+C, Tab, navegacion de historial
+- **Historial de comandos**: Recuperar comandos enviados previamente con busqueda
+- **Acciones rapidas**: Menu flotante para operaciones comunes (clear, cancel, exit)
+- **Indicador de conexion**: Estado del servidor en tiempo real con deteccion automatica de desconexion
+- **Verificador de actualizaciones**: Notificacion automatica de nuevas versiones desde GitHub releases
+- **PWA**: Instalable en la pantalla de inicio, funciona sin conexion
+- **Sesiones persistentes**: tmux mantiene las sesiones activas
+- **Barra lateral plegable**: Interfaz de escritorio con barra lateral de sesiones activable
+- **Modo pantalla completa**: Experiencia de terminal inmersiva
+- **Persistencia de configuracion**: Guardado automatico de ajustes de instalacion con contrasena cifrada AES-256
+
+## Capturas de Pantalla
+
+<p align="center">
+  <img src="docs/images/screenshots/mobile-terminal.png" alt="Terminal Movil" width="280" />
+  &nbsp;&nbsp;
+  <img src="docs/images/screenshots/mobile-sidebar.png" alt="Barra Lateral de Sesiones" width="280" />
+</p>
+
+## Arquitectura
+
+```mermaid
+flowchart TB
+    subgraph Client["Cliente (Movil/Escritorio)"]
+        PWA["PWA - React + TypeScript"]
+        Gestures["Controles por Gestos"]
+        Keyboard["Teclado Virtual"]
+    end
+
+    subgraph Server["tmux-api Server :7680"]
+        Static["Static Files"]
+        Proxy["WebSocket Proxy"]
+        API["REST API /api/tmux/*"]
+        Auth["Basic Auth"]
+    end
+
+    subgraph Backend["Backend Services"]
+        ttyd["ttyd :7681"]
+        tmux["tmux"]
+        Shell["Shell"]
+        Tools["CLI Tools"]
+    end
+
+    Gestures --> PWA
+    Keyboard --> PWA
+    PWA --> Static
+    PWA <--> Proxy
+    PWA --> API
+    Auth -.-> Static & Proxy & API
+    Proxy <--> ttyd
+    API --> tmux
+    ttyd --> tmux --> Shell --> Tools
+```
+
+## Inicio Rapido
+
+> 📖 **Nuevo en Termote?** Consulta la [Guia de Inicio](docs/getting-started.md) para un recorrido completo con ejemplos.
+
+```bash
+./scripts/termote.sh                   # Menu interactivo
+./scripts/termote.sh install container # Modo container (docker/podman)
+./scripts/termote.sh install native    # Modo nativo (herramientas del host)
+./scripts/termote.sh link              # Crear comando global 'termote'
+make test                              # Ejecutar tests
+```
+
+> Despues de `link`, usa `termote` desde cualquier lugar: `termote health`, `termote install native --lan`
+>
+> **Consejo**: Instala [gum](https://github.com/charmbracelet/gum) para menus interactivos mejorados (opcional, fallback bash disponible)
+
+## Instalacion
+
+### Una sola linea (recomendado)
+
+**macOS/Linux:**
+
+```bash
+# Descargar y preguntar antes de instalar (modo nativo por defecto)
+curl -fsSL https://raw.githubusercontent.com/lamngockhuong/termote/main/scripts/get.sh | bash
+
+# Instalar automaticamente sin preguntar
+curl -fsSL .../get.sh | bash -s -- --yes
+
+# Solo descargar (sin instalar)
+curl -fsSL .../get.sh | bash -s -- --download-only
+
+# Actualizar automaticamente con configuracion guardada
+curl -fsSL .../get.sh | bash -s -- --update
+
+# Instalar version especifica
+curl -fsSL .../get.sh | bash -s -- --version 0.0.4
+
+# Con modo y opciones explicitas
+curl -fsSL .../get.sh | bash -s -- --yes --container --lan
+curl -fsSL .../get.sh | bash -s -- --yes --native --tailscale myhost
+
+# Forzar nueva contrasena (ignorar configuracion guardada)
+curl -fsSL .../get.sh | bash -s -- --yes --container --fresh
+```
+
+**Windows (PowerShell):**
+
+> **Nota:** Si la ejecucion de scripts esta deshabilitada en tu sistema, ejecuta esto primero:
+>
+> ```powershell
+> Set-ExecutionPolicy -Scope CurrentUser -ExecutionPolicy RemoteSigned
+> ```
+
+```powershell
+# Descargar y preguntar antes de instalar (modo nativo por defecto)
+irm https://raw.githubusercontent.com/lamngockhuong/termote/main/scripts/get.ps1 | iex
+
+# Instalar automaticamente sin preguntar
+$env:TERMOTE_AUTO_YES = "true"; irm .../get.ps1 | iex
+
+# Con modo explicito
+$env:TERMOTE_MODE = "container"; irm .../get.ps1 | iex
+
+# Actualizar automaticamente con configuracion guardada
+$env:TERMOTE_UPDATE = "true"; irm .../get.ps1 | iex
+```
+
+### Docker
+
+```bash
+# Todo en uno (genera credenciales automaticamente, ver logs: docker logs termote)
+docker run -d --name termote -p 7680:7680 ghcr.io/lamngockhuong/termote:latest
+
+# Con credenciales personalizadas
+docker run -d --name termote -p 7680:7680 \
+  -e TERMOTE_USER=admin -e TERMOTE_PASS=secret \
+  ghcr.io/lamngockhuong/termote:latest
+
+# Sin autenticacion (solo desarrollo local)
+docker run -d --name termote -p 7680:7680 \
+  -e NO_AUTH=true \
+  ghcr.io/lamngockhuong/termote:latest
+
+# Con volumen para persistencia
+docker run -d --name termote -p 7680:7680 \
+  -v termote-data:/home/termote \
+  ghcr.io/lamngockhuong/termote:latest
+
+# Montar directorio de workspace personalizado
+docker run -d --name termote -p 7680:7680 \
+  -v ~/projects:/workspace \
+  ghcr.io/lamngockhuong/termote:latest
+
+# Con Tailscale HTTPS (requiere Tailscale en el host)
+docker run -d --name termote -p 7680:7680 \
+  -e TERMOTE_USER=admin -e TERMOTE_PASS=secret \
+  ghcr.io/lamngockhuong/termote:latest
+sudo tailscale serve --bg --https=443 http://127.0.0.1:7680
+# Acceder en: https://your-hostname.tailnet-name.ts.net
+```
+
+### Desde Release
+
+```bash
+# Descargar ultima release
+VERSION=$(curl -s https://api.github.com/repos/lamngockhuong/termote/releases/latest | grep tag_name | cut -d '"' -f4)
+wget https://github.com/lamngockhuong/termote/releases/download/${VERSION}/termote-${VERSION}.tar.gz
+tar xzf termote-${VERSION}.tar.gz
+cd termote-${VERSION#v}
+
+# Instalar (menu interactivo o con modo)
+./scripts/termote.sh install
+./scripts/termote.sh install container
+```
+
+### Desde Codigo Fuente
+
+```bash
+git clone https://github.com/lamngockhuong/termote.git
+cd termote
+./scripts/termote.sh install container
+```
+
+> **Nota**: `termote.sh` es el CLI unificado que soporta `install` (compila desde codigo fuente, usa artefactos pre-compilados cuando estan disponibles), `uninstall` y `health`.
+
+## Modos de Despliegue
+
+```mermaid
+flowchart LR
+    subgraph Container["Modo Container"]
+        direction TB
+        C1["Docker/Podman"] --> C2["tmux-api :7680"] --> C3["ttyd :7681"] --> C4["tmux"]
+    end
+
+    subgraph Native["Modo Nativo"]
+        direction TB
+        N1["Sistema Host"] --> N2["tmux-api :7680"] --> N3["ttyd :7681"] --> N4["tmux + Herramientas Host"]
+    end
+
+    User["Usuario"] --> Container & Native
+```
+
+| Modo          | Descripcion      | Caso de Uso                           | Plataforma   |
+| ------------- | ---------------- | ------------------------------------- | ------------ |
+| `--container` | Modo container   | Despliegue simple, entorno aislado    | macOS, Linux |
+| `--native`    | Todo nativo      | Acceso a herramientas host (claude, gh) | macOS, Linux |
+
+### Opciones
+
+| Flag                        | Descripcion                                          |
+| --------------------------- | ---------------------------------------------------- |
+| `--lan`                     | Exponer a LAN (por defecto: solo localhost)          |
+| `--tailscale <host[:port]>` | Habilitar Tailscale HTTPS                            |
+| `--no-auth`                 | Deshabilitar autenticacion basica                    |
+| `--port <port>`             | Puerto del host (por defecto: 7680, Windows: 7690)   |
+| `--fresh`                   | Forzar nueva contrasena (ignorar config guardada)    |
+| `--update`                  | Actualizar automaticamente con config guardada       |
+| `--version <ver>`           | Instalar version especifica (con o sin `v`)          |
+
+| Variable de Entorno | Descripcion                                            |
+| -------------------- | ------------------------------------------------------ |
+| `WORKSPACE`          | Directorio del host para montar (por defecto: `./workspace`) |
+| `TERMOTE_USER`       | Usuario de autenticacion (por defecto: auto-generado)  |
+| `TERMOTE_PASS`       | Contrasena de autenticacion (por defecto: auto-generada) |
+| `NO_AUTH`            | Establecer `true` para deshabilitar autenticacion      |
+
+### Modo Container (recomendado por simplicidad)
+
+Los scripts detectan automaticamente `podman` o `docker` -- ambos funcionan de forma identica.
+
+```bash
+./scripts/termote.sh install container             # localhost con basic auth
+./scripts/termote.sh install container --no-auth   # localhost sin auth
+./scripts/termote.sh install container --lan       # Accesible por LAN
+# Acceder: http://localhost:7680
+
+# Directorio de workspace personalizado (montado en /workspace en el container)
+WORKSPACE=~/projects ./scripts/termote.sh install container
+WORKSPACE=/path/to/code make install-container
+```
+
+> **Nota de seguridad**: Evita montar `$HOME` directamente -- los directorios sensibles como `.ssh`, `.gnupg` seran accesibles en el container. Monta directorios de proyecto especificos en su lugar.
+
+### Nativo (recomendado para acceso a binarios del host)
+
+Usar cuando necesites acceso a binarios del host (claude, git, etc.):
+
+```bash
+# Linux
+sudo apt install ttyd tmux
+# O: sudo snap install ttyd
+./scripts/termote.sh install native
+
+# macOS
+brew install ttyd tmux go
+./scripts/termote.sh install native
+# Acceder: http://localhost:7680
+```
+
+### Con Tailscale HTTPS (todos los modos)
+
+Usa `tailscale serve` para HTTPS automatico (sin gestion manual de certificados):
+
+```bash
+# Solo Tailscale (puerto por defecto 443)
+./scripts/termote.sh install container --tailscale myhost.ts.net
+
+# Puerto personalizado
+./scripts/termote.sh install native --tailscale myhost.ts.net:8765
+
+# Tailscale + accesible por LAN
+./scripts/termote.sh install container --tailscale myhost.ts.net --lan
+
+# Acceder: https://myhost.ts.net (o :8765 para puerto personalizado)
+```
+
+### Desinstalar
+
+```bash
+./scripts/termote.sh uninstall container   # Modo container
+./scripts/termote.sh uninstall native      # Modo nativo
+./scripts/termote.sh uninstall all         # Todo
+```
+
+### Actualizar
+
+```bash
+# Opcion 1: Actualizar automaticamente con config guardada
+curl -fsSL .../get.sh | bash -s -- --update
+
+# Opcion 2: Ejecutar el one-liner de nuevo (compara versiones, pregunta antes de instalar)
+curl -fsSL .../get.sh | bash
+
+# Opcion 3: Actualizacion manual
+./scripts/termote.sh uninstall [container|native]
+git pull origin main                    # Si se instalo desde codigo fuente
+./scripts/termote.sh install [container|native] [--lan] [--tailscale ...]
+```
+
+## Soporte de Plataformas
+
+| Plataforma | Container        | Nativo           | CLI Script  |
+| ---------- | ---------------- | ---------------- | ----------- |
+| Linux      | ✓                | ✓                | termote.sh  |
+| macOS      | ✓                | ✓                | termote.sh  |
+| Windows    | ⚠️ (experimental) | ⚠️ (experimental) | termote.ps1 |
+
+> **⚠️ Soporte de Windows (Experimental)**: El soporte de Windows esta actualmente en etapas tempranas y necesita mas pruebas. El modo container requiere Docker Desktop, el modo nativo requiere psmux. Por favor reporta problemas en GitHub.
+
+### Modo Nativo de Windows
+
+El modo nativo de Windows usa [psmux](https://github.com/psmux/psmux) (multiplexor de terminal compatible con tmux para Windows):
+
+```powershell
+# Instalar psmux
+winget install psmux
+
+# Ejecutar Termote
+.\scripts\termote.ps1 install native
+.\scripts\termote.ps1 install container  # O modo container con Docker Desktop
+```
+
+## Uso en Movil
+
+| Accion             | Gesto               |
+| ------------------ | -------------------- |
+| Cancelar/interrumpir | Deslizar izquierda (Ctrl+C) |
+| Tab completion     | Deslizar derecha     |
+| Historial arriba   | Deslizar arriba      |
+| Historial abajo    | Deslizar abajo       |
+| Pegar              | Mantener presionado  |
+| Tamano de fuente   | Pellizcar            |
+
+La barra de herramientas virtual proporciona: Tab, Esc, Ctrl, Shift, teclas de flechas y combinaciones de teclas comunes. Soporta combinaciones Ctrl+Shift (pegar, copiar). Alterna entre modo minimal y expandido para teclas adicionales (Home, End, Delete, etc.).
+
+## Estructura del Proyecto
+
+```
+termote/
+├── Makefile                # Comandos de build/test/deploy
+├── Dockerfile              # Modo Docker (tmux-api + ttyd)
+├── docker-compose.yml
+├── entrypoint.sh           # Docker entrypoint
+├── docs/                   # Documentacion
+│   └── images/screenshots/ # Capturas de pantalla de la app
+├── pwa/                    # React PWA
+│   └── src/
+│       ├── components/
+│       ├── contexts/
+│       ├── hooks/
+│       ├── types/
+│       └── utils/
+├── tmux-api/               # Go server
+│   ├── main.go             # Punto de entrada
+│   ├── serve.go            # Servidor (PWA, proxy, auth)
+│   └── tmux.go             # Manejadores de la API tmux
+├── scripts/
+│   ├── termote.sh          # Unix CLI (install/uninstall/health)
+│   ├── termote.ps1         # Windows PowerShell CLI
+│   ├── get.sh              # Instalador online Unix (curl | bash)
+│   └── get.ps1             # Instalador online Windows (irm | iex)
+├── tests/                  # Suite de tests
+│   ├── test-termote.sh
+│   ├── test-termote.ps1    # Tests de Windows
+│   ├── test-get.sh
+│   └── test-entrypoints.sh
+└── website/                # Sitio de docs Astro Starlight
+    └── src/content/docs/   # Documentacion MDX
+```
+
+## Desarrollo
+
+```bash
+make build          # Compilar PWA y tmux-api
+make test           # Ejecutar todos los tests
+make health         # Verificar estado de los servicios
+make clean          # Detener containers
+
+# E2E tests (requiere servidor en ejecucion)
+./scripts/termote.sh install container  # Iniciar servidor primero
+cd pwa && pnpm test:e2e       # Ejecutar tests de Playwright
+cd pwa && pnpm test:e2e:ui    # Ejecutar con UI debugger
+```
+
+**Pruebas Manuales:** Ver [Lista de Verificacion](docs/self-test-checklist.md)
+
+## Solucion de Problemas
+
+### La sesion no persiste
+
+- Verificar tmux: `tmux ls`
+- Verificar que ttyd usa el flag `-A` (attach-or-create)
+
+### Errores de WebSocket
+
+- Verificar logs de tmux-api: `docker logs termote`
+- Verificar que ttyd esta ejecutandose en el puerto 7681
+
+### Problemas con el teclado en movil
+
+- Asegurar que la meta tag de viewport esta presente
+- Probar en un dispositivo real, no en un emulador
+
+### Modo nativo: los procesos no inician
+
+```bash
+ps aux | grep ttyd         # Verificar si ttyd esta ejecutandose
+ps aux | grep tmux-api     # Verificar si tmux-api esta ejecutandose
+lsof -i :7680              # Verificar que el puerto esta en uso
+```
+
+## Notas de Seguridad
+
+- **Por defecto: solo localhost** - no se expone a LAN a menos que se use el flag `--lan`
+- **Autenticacion basica habilitada por defecto** - usa `--no-auth` para deshabilitar en desarrollo local
+- **Proteccion contra fuerza bruta integrada** - limitacion de tasa (5 intentos/min por IP)
+- Usar HTTPS (Tailscale) para produccion
+- Restringir a redes de confianza/VPN
+
+## Licencia
+
+MIT

--- a/README.fr.md
+++ b/README.fr.md
@@ -1,0 +1,453 @@
+<p align="center">
+  <img src="pwa/public/banner-readme.svg" alt="Termote" width="600" />
+</p>
+
+<p align="center">
+  <a href="https://github.com/lamngockhuong/termote/releases"><img src="https://img.shields.io/github/v/release/lamngockhuong/termote?style=flat-square&color=blue" alt="Release" /></a>
+  <a href="https://github.com/lamngockhuong/termote/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/lamngockhuong/termote/ci.yml?branch=main&style=flat-square&label=CI" alt="CI" /></a>
+  <a href="https://github.com/lamngockhuong/termote/blob/main/LICENSE"><img src="https://img.shields.io/github/license/lamngockhuong/termote?style=flat-square" alt="License" /></a>
+  <a href="https://ghcr.io/lamngockhuong/termote"><img src="https://img.shields.io/badge/GHCR-termote-blue?style=flat-square&logo=github" alt="GHCR" /></a>
+  <a href="https://hub.docker.com/r/lamngockhuong/termote"><img src="https://img.shields.io/docker/pulls/lamngockhuong/termote?style=flat-square&logo=docker" alt="Docker Pulls" /></a>
+</p>
+
+<p align="center">
+  <img src="https://img.shields.io/badge/Go-1.21-00ADD8?style=flat-square&logo=go&logoColor=white" alt="Go" />
+  <img src="https://img.shields.io/badge/React-19-61DAFB?style=flat-square&logo=react&logoColor=black" alt="React" />
+  <img src="https://img.shields.io/badge/TypeScript-5.9-3178C6?style=flat-square&logo=typescript&logoColor=white" alt="TypeScript" />
+  <img src="https://img.shields.io/badge/PWA-ready-5A0FC8?style=flat-square&logo=pwa&logoColor=white" alt="PWA" />
+</p>
+
+<p align="center">
+  <a href="https://launch.j2team.dev/products/termote?utm_source=badge-launched&utm_medium=badge&utm_campaign=badge-termote" target="_blank" rel="noopener noreferrer"><img src="https://launch.j2team.dev/badge/termote/dark" alt="Termote - Launched on J2TEAM Launch" width="170" height="36" loading="lazy" /></a>
+  &nbsp;
+  <a href="https://unikorn.vn/p/termote?ref=embed-termote" target="_blank"><img src="https://unikorn.vn/api/widgets/badge/termote?theme=dark" alt="Termote trên Unikorn.vn" width="170" height="42" /></a>
+</p>
+
+Contrôlez à distance des outils CLI (Claude Code, GitHub Copilot, n'importe quel terminal) depuis mobile/desktop via PWA.
+
+> **Termote** = Terminal + Remote
+>
+> 🇬🇧 [English](README.md) | 🇻🇳 [Tiếng Việt](README.vi.md) | 🇨🇳 [简体中文](README.zh-CN.md) | 🇯🇵 [日本語](README.ja.md) | 🇰🇷 [한국어](README.ko.md) | 🇪🇸 [Español](README.es.md) | 🇧🇷 [Português (BR)](README.pt-BR.md) | 🇩🇪 [Deutsch](README.de.md) | 🇷🇺 [Русский](README.ru.md) | 🇮🇩 [Bahasa Indonesia](README.id.md)
+
+## Fonctionnalités
+
+- **Changement de session** : Plusieurs sessions tmux avec création/modification/suppression
+- **Onglets de session** : Barre d'onglets horizontale pour basculer rapidement entre les fenêtres
+- **Adapté au mobile** : Barre d'outils clavier virtuel (Tab/Ctrl/Shift/flèches, extensible)
+- **Support des gestes** : Balayage pour Ctrl+C, Tab, navigation dans l'historique
+- **Historique des commandes** : Rappel des commandes envoyées avec recherche
+- **Actions rapides** : Menu flottant pour les opérations courantes (clear, cancel, exit)
+- **Indicateur de connexion** : Statut du serveur en temps réel avec détection automatique de déconnexion
+- **Vérification des mises à jour** : Notification automatique de nouvelle version depuis les releases GitHub
+- **PWA** : Installable sur l'écran d'accueil, utilisable hors ligne
+- **Sessions persistantes** : tmux maintient les sessions actives
+- **Barre latérale repliable** : Interface desktop avec barre latérale de sessions activable
+- **Mode plein écran** : Expérience terminal immersive
+- **Persistance de la configuration** : Sauvegarde automatique des paramètres avec mot de passe chiffré AES-256
+
+## Captures d'Écran
+
+<p align="center">
+  <img src="docs/images/screenshots/mobile-terminal.png" alt="Terminal Mobile" width="280" />
+  &nbsp;&nbsp;
+  <img src="docs/images/screenshots/mobile-sidebar.png" alt="Barre Latérale de Session" width="280" />
+</p>
+
+## Architecture
+
+```mermaid
+flowchart TB
+    subgraph Client["Client (Mobile/Desktop)"]
+        PWA["PWA - React + TypeScript"]
+        Gestures["Contrôles Gestuels"]
+        Keyboard["Clavier Virtuel"]
+    end
+
+    subgraph Server["tmux-api Server :7680"]
+        Static["Static Files"]
+        Proxy["WebSocket Proxy"]
+        API["REST API /api/tmux/*"]
+        Auth["Basic Auth"]
+    end
+
+    subgraph Backend["Services Backend"]
+        ttyd["ttyd :7681"]
+        tmux["tmux"]
+        Shell["Shell"]
+        Tools["Outils CLI"]
+    end
+
+    Gestures --> PWA
+    Keyboard --> PWA
+    PWA --> Static
+    PWA <--> Proxy
+    PWA --> API
+    Auth -.-> Static & Proxy & API
+    Proxy <--> ttyd
+    API --> tmux
+    ttyd --> tmux --> Shell --> Tools
+```
+
+## Démarrage Rapide
+
+> 📖 **Nouveau sur Termote ?** Consultez le [Guide de Démarrage](docs/getting-started.md) pour une présentation complète avec des exemples.
+
+```bash
+./scripts/termote.sh                   # Menu interactif
+./scripts/termote.sh install container # Mode conteneur (docker/podman)
+./scripts/termote.sh install native    # Mode natif (outils de l'hôte)
+./scripts/termote.sh link              # Créer la commande globale 'termote'
+make test                              # Lancer les tests
+```
+
+> Après `link`, utilisez `termote` depuis n'importe où : `termote health`, `termote install native --lan`
+>
+> **Astuce** : Installez [gum](https://github.com/charmbracelet/gum) pour des menus interactifs améliorés (optionnel, fallback bash disponible)
+
+## Installation
+
+### Une seule ligne (recommandé)
+
+**macOS/Linux :**
+
+```bash
+# Télécharger et demander avant d'installer (mode natif par défaut)
+curl -fsSL https://raw.githubusercontent.com/lamngockhuong/termote/main/scripts/get.sh | bash
+
+# Installation automatique sans confirmation
+curl -fsSL .../get.sh | bash -s -- --yes
+
+# Téléchargement uniquement (sans installation)
+curl -fsSL .../get.sh | bash -s -- --download-only
+
+# Mise à jour automatique avec la configuration sauvegardée
+curl -fsSL .../get.sh | bash -s -- --update
+
+# Installer une version spécifique
+curl -fsSL .../get.sh | bash -s -- --version 0.0.4
+
+# Avec mode et options explicites
+curl -fsSL .../get.sh | bash -s -- --yes --container --lan
+curl -fsSL .../get.sh | bash -s -- --yes --native --tailscale myhost
+
+# Forcer un nouveau mot de passe (ignorer la configuration sauvegardée)
+curl -fsSL .../get.sh | bash -s -- --yes --container --fresh
+```
+
+**Windows (PowerShell) :**
+
+> **Remarque :** Si l'exécution de scripts est désactivée sur votre système, exécutez d'abord ceci :
+>
+> ```powershell
+> Set-ExecutionPolicy -Scope CurrentUser -ExecutionPolicy RemoteSigned
+> ```
+
+```powershell
+# Télécharger et demander avant d'installer (mode natif par défaut)
+irm https://raw.githubusercontent.com/lamngockhuong/termote/main/scripts/get.ps1 | iex
+
+# Installation automatique sans confirmation
+$env:TERMOTE_AUTO_YES = "true"; irm .../get.ps1 | iex
+
+# Avec mode explicite
+$env:TERMOTE_MODE = "container"; irm .../get.ps1 | iex
+
+# Mise à jour automatique avec la configuration sauvegardée
+$env:TERMOTE_UPDATE = "true"; irm .../get.ps1 | iex
+```
+
+### Docker
+
+```bash
+# Tout-en-un (génération automatique des identifiants, voir les logs : docker logs termote)
+docker run -d --name termote -p 7680:7680 ghcr.io/lamngockhuong/termote:latest
+
+# Avec identifiants personnalisés
+docker run -d --name termote -p 7680:7680 \
+  -e TERMOTE_USER=admin -e TERMOTE_PASS=secret \
+  ghcr.io/lamngockhuong/termote:latest
+
+# Sans authentification (dev local uniquement)
+docker run -d --name termote -p 7680:7680 \
+  -e NO_AUTH=true \
+  ghcr.io/lamngockhuong/termote:latest
+
+# Avec volume pour la persistance
+docker run -d --name termote -p 7680:7680 \
+  -v termote-data:/home/termote \
+  ghcr.io/lamngockhuong/termote:latest
+
+# Monter un répertoire workspace personnalisé
+docker run -d --name termote -p 7680:7680 \
+  -v ~/projects:/workspace \
+  ghcr.io/lamngockhuong/termote:latest
+
+# Avec Tailscale HTTPS (nécessite Tailscale sur l'hôte)
+docker run -d --name termote -p 7680:7680 \
+  -e TERMOTE_USER=admin -e TERMOTE_PASS=secret \
+  ghcr.io/lamngockhuong/termote:latest
+sudo tailscale serve --bg --https=443 http://127.0.0.1:7680
+# Accès : https://your-hostname.tailnet-name.ts.net
+```
+
+### Depuis une Release
+
+```bash
+# Télécharger la dernière release
+VERSION=$(curl -s https://api.github.com/repos/lamngockhuong/termote/releases/latest | grep tag_name | cut -d '"' -f4)
+wget https://github.com/lamngockhuong/termote/releases/download/${VERSION}/termote-${VERSION}.tar.gz
+tar xzf termote-${VERSION}.tar.gz
+cd termote-${VERSION#v}
+
+# Installer (menu interactif ou avec mode)
+./scripts/termote.sh install
+./scripts/termote.sh install container
+```
+
+### Depuis les Sources
+
+```bash
+git clone https://github.com/lamngockhuong/termote.git
+cd termote
+./scripts/termote.sh install container
+```
+
+> **Remarque** : `termote.sh` est le CLI unifié prenant en charge `install` (build depuis les sources, utilise les artefacts pré-compilés si disponibles), `uninstall` et `health`.
+
+## Modes de Déploiement
+
+```mermaid
+flowchart LR
+    subgraph Container["Mode Conteneur"]
+        direction TB
+        C1["Docker/Podman"] --> C2["tmux-api :7680"] --> C3["ttyd :7681"] --> C4["tmux"]
+    end
+
+    subgraph Native["Mode Natif"]
+        direction TB
+        N1["Système Hôte"] --> N2["tmux-api :7680"] --> N3["ttyd :7681"] --> N4["tmux + Outils Hôte"]
+    end
+
+    User["Utilisateur"] --> Container & Native
+```
+
+| Mode          | Description      | Cas d'utilisation                            | Plateforme   |
+| ------------- | ---------------- | -------------------------------------------- | ------------ |
+| `--container` | Mode conteneur   | Déploiement simple, environnement isolé      | macOS, Linux |
+| `--native`    | Tout en natif    | Accès aux outils de l'hôte (claude, gh)      | macOS, Linux |
+
+### Options
+
+| Flag                        | Description                                                  |
+| --------------------------- | ------------------------------------------------------------ |
+| `--lan`                     | Exposer sur le LAN (par défaut : localhost uniquement)       |
+| `--tailscale <host[:port]>` | Activer Tailscale HTTPS                                     |
+| `--no-auth`                 | Désactiver l'authentification basique                        |
+| `--port <port>`             | Port hôte (par défaut : 7680, Windows : 7690)               |
+| `--fresh`                   | Forcer un nouveau mot de passe (ignorer la config sauvegardée) |
+| `--update`                  | Mise à jour automatique avec la config sauvegardée           |
+| `--version <ver>`           | Installer une version spécifique (avec ou sans `v`)          |
+
+| Variable d'environnement | Description                                                |
+| ------------------------ | ---------------------------------------------------------- |
+| `WORKSPACE`              | Répertoire hôte à monter (par défaut : `./workspace`)      |
+| `TERMOTE_USER`           | Nom d'utilisateur auth (par défaut : généré automatiquement) |
+| `TERMOTE_PASS`           | Mot de passe auth (par défaut : généré automatiquement)    |
+| `NO_AUTH`                | Définir à `true` pour désactiver l'authentification        |
+
+### Mode Conteneur (recommandé pour la simplicité)
+
+Les scripts détectent automatiquement `podman` ou `docker` — les deux fonctionnent de manière identique.
+
+```bash
+./scripts/termote.sh install container             # localhost avec basic auth
+./scripts/termote.sh install container --no-auth   # localhost sans auth
+./scripts/termote.sh install container --lan       # Accessible sur le LAN
+# Accès : http://localhost:7680
+
+# Répertoire workspace personnalisé (monté dans /workspace dans le conteneur)
+WORKSPACE=~/projects ./scripts/termote.sh install container
+WORKSPACE=/path/to/code make install-container
+```
+
+> **Note de sécurité** : Évitez de monter `$HOME` directement — les répertoires sensibles comme `.ssh`, `.gnupg` seront accessibles dans le conteneur. Montez des répertoires de projet spécifiques à la place.
+
+### Natif (recommandé pour l'accès aux binaires de l'hôte)
+
+À utiliser lorsque vous avez besoin d'accéder aux binaires de l'hôte (claude, git, etc.) :
+
+```bash
+# Linux
+sudo apt install ttyd tmux
+# Ou : sudo snap install ttyd
+./scripts/termote.sh install native
+
+# macOS
+brew install ttyd tmux go
+./scripts/termote.sh install native
+# Accès : http://localhost:7680
+```
+
+### Avec Tailscale HTTPS (tous les modes)
+
+Utilise `tailscale serve` pour le HTTPS automatique (pas de gestion manuelle des certificats) :
+
+```bash
+# Tailscale uniquement (port par défaut 443)
+./scripts/termote.sh install container --tailscale myhost.ts.net
+
+# Port personnalisé
+./scripts/termote.sh install native --tailscale myhost.ts.net:8765
+
+# Tailscale + accessible sur le LAN
+./scripts/termote.sh install container --tailscale myhost.ts.net --lan
+
+# Accès : https://myhost.ts.net (ou :8765 pour un port personnalisé)
+```
+
+### Désinstallation
+
+```bash
+./scripts/termote.sh uninstall container   # Mode conteneur
+./scripts/termote.sh uninstall native      # Mode natif
+./scripts/termote.sh uninstall all         # Tout
+```
+
+### Mise à Jour
+
+```bash
+# Option 1 : Mise à jour automatique avec la config sauvegardée
+curl -fsSL .../get.sh | bash -s -- --update
+
+# Option 2 : Relancer la commande one-liner (compare les versions, demande avant d'installer)
+curl -fsSL .../get.sh | bash
+
+# Option 3 : Mise à jour manuelle
+./scripts/termote.sh uninstall [container|native]
+git pull origin main                    # Si installé depuis les sources
+./scripts/termote.sh install [container|native] [--lan] [--tailscale ...]
+```
+
+## Support des Plateformes
+
+| Plateforme | Conteneur          | Natif              | Script CLI  |
+| ---------- | ------------------ | ------------------ | ----------- |
+| Linux      | ✓                  | ✓                  | termote.sh  |
+| macOS      | ✓                  | ✓                  | termote.sh  |
+| Windows    | ⚠️ (expérimental)   | ⚠️ (expérimental)   | termote.ps1 |
+
+> **⚠️ Support Windows (Expérimental)** : Le support Windows est actuellement en phase initiale et nécessite davantage de tests. Le mode conteneur nécessite Docker Desktop, le mode natif nécessite psmux. Veuillez signaler les problèmes sur GitHub.
+
+### Mode Natif Windows
+
+Le mode natif Windows utilise [psmux](https://github.com/psmux/psmux) (multiplexeur de terminal compatible tmux pour Windows) :
+
+```powershell
+# Installer psmux
+winget install psmux
+
+# Lancer Termote
+.\scripts\termote.ps1 install native
+.\scripts\termote.ps1 install container  # Ou mode conteneur avec Docker Desktop
+```
+
+## Utilisation Mobile
+
+| Action              | Geste                |
+| ------------------- | -------------------- |
+| Annuler/interrompre | Balayage gauche (Ctrl+C) |
+| Complétion Tab      | Balayage droit       |
+| Historique haut     | Balayage haut        |
+| Historique bas      | Balayage bas         |
+| Coller              | Appui long           |
+| Taille de police    | Pincement entrée/sortie |
+
+La barre d'outils virtuelle fournit : Tab, Esc, Ctrl, Shift, touches fléchées et combinaisons de touches courantes. Supporte les combinaisons Ctrl+Shift (coller, copier). Basculez entre le mode minimal et le mode étendu pour des touches supplémentaires (Home, End, Delete, etc.).
+
+## Structure du Projet
+
+```
+termote/
+├── Makefile                # Commandes build/test/deploy
+├── Dockerfile              # Mode Docker (tmux-api + ttyd)
+├── docker-compose.yml
+├── entrypoint.sh           # Point d'entrée Docker
+├── docs/                   # Documentation
+│   └── images/screenshots/ # Captures d'écran de l'app
+├── pwa/                    # React PWA
+│   └── src/
+│       ├── components/
+│       ├── contexts/
+│       ├── hooks/
+│       ├── types/
+│       └── utils/
+├── tmux-api/               # Serveur Go
+│   ├── main.go             # Point d'entrée
+│   ├── serve.go            # Serveur (PWA, proxy, auth)
+│   └── tmux.go             # Handlers API tmux
+├── scripts/
+│   ├── termote.sh          # CLI Unix (install/uninstall/health)
+│   ├── termote.ps1         # CLI Windows PowerShell
+│   ├── get.sh              # Installateur en ligne Unix (curl | bash)
+│   └── get.ps1             # Installateur en ligne Windows (irm | iex)
+├── tests/                  # Suite de tests
+│   ├── test-termote.sh
+│   ├── test-termote.ps1    # Tests Windows
+│   ├── test-get.sh
+│   └── test-entrypoints.sh
+└── website/                # Site docs Astro Starlight
+    └── src/content/docs/   # Documentation MDX
+```
+
+## Développement
+
+```bash
+make build          # Build PWA et tmux-api
+make test           # Lancer tous les tests
+make health         # Vérifier la santé des services
+make clean          # Arrêter les conteneurs
+
+# Tests E2E (nécessite un serveur en cours d'exécution)
+./scripts/termote.sh install container  # Démarrer le serveur d'abord
+cd pwa && pnpm test:e2e       # Lancer les tests Playwright
+cd pwa && pnpm test:e2e:ui    # Lancer avec le débogueur UI
+```
+
+**Tests Manuels :** Voir [Liste de Vérification](docs/self-test-checklist.md)
+
+## Dépannage
+
+### La session ne persiste pas
+
+- Vérifier tmux : `tmux ls`
+- Vérifier que ttyd utilise le flag `-A` (attach-or-create)
+
+### Erreurs WebSocket
+
+- Vérifier les logs tmux-api : `docker logs termote`
+- Vérifier que ttyd fonctionne sur le port 7681
+
+### Problèmes de clavier mobile
+
+- S'assurer que la balise meta viewport est présente
+- Tester sur un appareil réel, pas un émulateur
+
+### Mode natif : les processus ne démarrent pas
+
+```bash
+ps aux | grep ttyd         # Vérifier si ttyd est en cours d'exécution
+ps aux | grep tmux-api     # Vérifier si tmux-api est en cours d'exécution
+lsof -i :7680              # Vérifier que le port est utilisé
+```
+
+## Notes de Sécurité
+
+- **Par défaut : localhost uniquement** - non exposé au LAN sauf si le flag `--lan` est utilisé
+- **Authentification basique activée par défaut** - utilisez `--no-auth` pour désactiver en dev local
+- **Protection anti-brute-force intégrée** - limitation de débit (5 tentatives/min par IP)
+- Utilisez HTTPS (Tailscale) pour la production
+- Restreignez aux réseaux de confiance/VPN
+
+## Licence
+
+MIT

--- a/README.id.md
+++ b/README.id.md
@@ -1,0 +1,453 @@
+<p align="center">
+  <img src="pwa/public/banner-readme.svg" alt="Termote" width="600" />
+</p>
+
+<p align="center">
+  <a href="https://github.com/lamngockhuong/termote/releases"><img src="https://img.shields.io/github/v/release/lamngockhuong/termote?style=flat-square&color=blue" alt="Release" /></a>
+  <a href="https://github.com/lamngockhuong/termote/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/lamngockhuong/termote/ci.yml?branch=main&style=flat-square&label=CI" alt="CI" /></a>
+  <a href="https://github.com/lamngockhuong/termote/blob/main/LICENSE"><img src="https://img.shields.io/github/license/lamngockhuong/termote?style=flat-square" alt="License" /></a>
+  <a href="https://ghcr.io/lamngockhuong/termote"><img src="https://img.shields.io/badge/GHCR-termote-blue?style=flat-square&logo=github" alt="GHCR" /></a>
+  <a href="https://hub.docker.com/r/lamngockhuong/termote"><img src="https://img.shields.io/docker/pulls/lamngockhuong/termote?style=flat-square&logo=docker" alt="Docker Pulls" /></a>
+</p>
+
+<p align="center">
+  <img src="https://img.shields.io/badge/Go-1.21-00ADD8?style=flat-square&logo=go&logoColor=white" alt="Go" />
+  <img src="https://img.shields.io/badge/React-19-61DAFB?style=flat-square&logo=react&logoColor=black" alt="React" />
+  <img src="https://img.shields.io/badge/TypeScript-5.9-3178C6?style=flat-square&logo=typescript&logoColor=white" alt="TypeScript" />
+  <img src="https://img.shields.io/badge/PWA-ready-5A0FC8?style=flat-square&logo=pwa&logoColor=white" alt="PWA" />
+</p>
+
+<p align="center">
+  <a href="https://launch.j2team.dev/products/termote?utm_source=badge-launched&utm_medium=badge&utm_campaign=badge-termote" target="_blank" rel="noopener noreferrer"><img src="https://launch.j2team.dev/badge/termote/dark" alt="Termote - Launched on J2TEAM Launch" width="170" height="36" loading="lazy" /></a>
+  &nbsp;
+  <a href="https://unikorn.vn/p/termote?ref=embed-termote" target="_blank"><img src="https://unikorn.vn/api/widgets/badge/termote?theme=dark" alt="Termote trên Unikorn.vn" width="170" height="42" /></a>
+</p>
+
+Kendalikan alat CLI (Claude Code, GitHub Copilot, terminal apa pun) dari jarak jauh melalui mobile/desktop via PWA.
+
+> **Termote** = Terminal + Remote
+>
+> 🇬🇧 [English](README.md) | 🇻🇳 [Tiếng Việt](README.vi.md) | 🇨🇳 [简体中文](README.zh-CN.md) | 🇯🇵 [日本語](README.ja.md) | 🇰🇷 [한국어](README.ko.md) | 🇪🇸 [Español](README.es.md) | 🇧🇷 [Português (BR)](README.pt-BR.md) | 🇫🇷 [Français](README.fr.md) | 🇩🇪 [Deutsch](README.de.md) | 🇷🇺 [Русский](README.ru.md)
+
+## Fitur
+
+- **Pergantian session**: Banyak tmux sessions dengan buat/edit/hapus
+- **Tab session**: Bilah tab horizontal untuk berpindah jendela dengan cepat
+- **Ramah mobile**: Toolbar keyboard virtual (Tab/Ctrl/Shift/panah, dapat diperluas)
+- **Dukungan gestur**: Geser untuk Ctrl+C, Tab, navigasi riwayat
+- **Riwayat perintah**: Panggil ulang perintah yang pernah dikirim dengan pencarian
+- **Aksi cepat**: Menu mengambang untuk operasi umum (clear, cancel, exit)
+- **Indikator koneksi**: Status server real-time, deteksi otomatis koneksi terputus
+- **Pemeriksa pembaruan**: Notifikasi otomatis versi baru dari GitHub releases
+- **PWA**: Dapat dipasang di homescreen, tersedia offline
+- **Session persisten**: tmux menjaga session tetap hidup
+- **Sidebar dapat dilipat**: UI desktop dengan sidebar session yang bisa ditampilkan/disembunyikan
+- **Mode layar penuh**: Pengalaman terminal secara layar penuh
+- **Penyimpanan konfigurasi**: Otomatis menyimpan pengaturan instalasi dengan password terenkripsi AES-256
+
+## Tangkapan Layar
+
+<p align="center">
+  <img src="docs/images/screenshots/mobile-terminal.png" alt="Mobile Terminal" width="280" />
+  &nbsp;&nbsp;
+  <img src="docs/images/screenshots/mobile-sidebar.png" alt="Session Sidebar" width="280" />
+</p>
+
+## Arsitektur
+
+```mermaid
+flowchart TB
+    subgraph Client["Client (Mobile/Desktop)"]
+        PWA["PWA - React + TypeScript"]
+        Gestures["Kontrol Gestur"]
+        Keyboard["Keyboard Virtual"]
+    end
+
+    subgraph Server["tmux-api Server :7680"]
+        Static["Static Files"]
+        Proxy["WebSocket Proxy"]
+        API["REST API /api/tmux/*"]
+        Auth["Basic Auth"]
+    end
+
+    subgraph Backend["Layanan Backend"]
+        ttyd["ttyd :7681"]
+        tmux["tmux"]
+        Shell["Shell"]
+        Tools["CLI Tools"]
+    end
+
+    Gestures --> PWA
+    Keyboard --> PWA
+    PWA --> Static
+    PWA <--> Proxy
+    PWA --> API
+    Auth -.-> Static & Proxy & API
+    Proxy <--> ttyd
+    API --> tmux
+    ttyd --> tmux --> Shell --> Tools
+```
+
+## Mulai Cepat
+
+> 📖 **Baru mengenal Termote?** Lihat [Panduan Memulai](docs/getting-started.md) untuk panduan lengkap dengan contoh.
+
+```bash
+./scripts/termote.sh                   # Menu interaktif
+./scripts/termote.sh install container # Mode container (docker/podman)
+./scripts/termote.sh install native    # Mode native (alat host)
+./scripts/termote.sh link              # Buat perintah 'termote' global
+make test                              # Jalankan tes
+```
+
+> Setelah `link`, gunakan `termote` dari mana saja: `termote health`, `termote install native --lan`
+>
+> **Tips**: Instal [gum](https://github.com/charmbracelet/gum) untuk menu interaktif yang lebih baik (opsional, tersedia fallback bash)
+
+## Instalasi
+
+### Satu baris perintah (direkomendasikan)
+
+**macOS/Linux:**
+
+```bash
+# Unduh dan tanya sebelum instal (default mode native)
+curl -fsSL https://raw.githubusercontent.com/lamngockhuong/termote/main/scripts/get.sh | bash
+
+# Instal otomatis tanpa bertanya
+curl -fsSL .../get.sh | bash -s -- --yes
+
+# Hanya unduh (tanpa instal)
+curl -fsSL .../get.sh | bash -s -- --download-only
+
+# Pembaruan otomatis dengan config tersimpan
+curl -fsSL .../get.sh | bash -s -- --update
+
+# Instal versi tertentu
+curl -fsSL .../get.sh | bash -s -- --version 0.0.4
+
+# Dengan mode dan opsi tertentu
+curl -fsSL .../get.sh | bash -s -- --yes --container --lan
+curl -fsSL .../get.sh | bash -s -- --yes --native --tailscale myhost
+
+# Paksa password baru (abaikan config tersimpan)
+curl -fsSL .../get.sh | bash -s -- --yes --container --fresh
+```
+
+**Windows (PowerShell):**
+
+> **Catatan:** Jika eksekusi skrip dinonaktifkan di sistem Anda, jalankan perintah ini terlebih dahulu:
+>
+> ```powershell
+> Set-ExecutionPolicy -Scope CurrentUser -ExecutionPolicy RemoteSigned
+> ```
+
+```powershell
+# Unduh dan tanya sebelum instal (default mode native)
+irm https://raw.githubusercontent.com/lamngockhuong/termote/main/scripts/get.ps1 | iex
+
+# Instal otomatis tanpa bertanya
+$env:TERMOTE_AUTO_YES = "true"; irm .../get.ps1 | iex
+
+# Dengan mode tertentu
+$env:TERMOTE_MODE = "container"; irm .../get.ps1 | iex
+
+# Pembaruan otomatis dengan config tersimpan
+$env:TERMOTE_UPDATE = "true"; irm .../get.ps1 | iex
+```
+
+### Docker
+
+```bash
+# Semua dalam satu (credentials otomatis, lihat logs: docker logs termote)
+docker run -d --name termote -p 7680:7680 ghcr.io/lamngockhuong/termote:latest
+
+# Dengan credentials khusus
+docker run -d --name termote -p 7680:7680 \
+  -e TERMOTE_USER=admin -e TERMOTE_PASS=secret \
+  ghcr.io/lamngockhuong/termote:latest
+
+# Tanpa autentikasi (hanya dev lokal)
+docker run -d --name termote -p 7680:7680 \
+  -e NO_AUTH=true \
+  ghcr.io/lamngockhuong/termote:latest
+
+# Dengan volume untuk penyimpanan
+docker run -d --name termote -p 7680:7680 \
+  -v termote-data:/home/termote \
+  ghcr.io/lamngockhuong/termote:latest
+
+# Mount direktori workspace khusus
+docker run -d --name termote -p 7680:7680 \
+  -v ~/projects:/workspace \
+  ghcr.io/lamngockhuong/termote:latest
+
+# Dengan Tailscale HTTPS (memerlukan Tailscale di host)
+docker run -d --name termote -p 7680:7680 \
+  -e TERMOTE_USER=admin -e TERMOTE_PASS=secret \
+  ghcr.io/lamngockhuong/termote:latest
+sudo tailscale serve --bg --https=443 http://127.0.0.1:7680
+# Akses di: https://your-hostname.tailnet-name.ts.net
+```
+
+### Dari Release
+
+```bash
+# Unduh release terbaru
+VERSION=$(curl -s https://api.github.com/repos/lamngockhuong/termote/releases/latest | grep tag_name | cut -d '"' -f4)
+wget https://github.com/lamngockhuong/termote/releases/download/${VERSION}/termote-${VERSION}.tar.gz
+tar xzf termote-${VERSION}.tar.gz
+cd termote-${VERSION#v}
+
+# Instal (menu interaktif atau dengan mode)
+./scripts/termote.sh install
+./scripts/termote.sh install container
+```
+
+### Dari Source
+
+```bash
+git clone https://github.com/lamngockhuong/termote.git
+cd termote
+./scripts/termote.sh install container
+```
+
+> **Catatan**: `termote.sh` adalah CLI terpadu yang mendukung `install` (build dari source, menggunakan artifacts yang tersedia jika ada), `uninstall`, dan `health`.
+
+## Mode Deployment
+
+```mermaid
+flowchart LR
+    subgraph Container["Mode Container"]
+        direction TB
+        C1["Docker/Podman"] --> C2["tmux-api :7680"] --> C3["ttyd :7681"] --> C4["tmux"]
+    end
+
+    subgraph Native["Mode Native"]
+        direction TB
+        N1["Sistem Host"] --> N2["tmux-api :7680"] --> N3["ttyd :7681"] --> N4["tmux + Alat Host"]
+    end
+
+    User["Pengguna"] --> Container & Native
+```
+
+| Mode          | Deskripsi      | Kasus Penggunaan                         | Platform     |
+| ------------- | -------------- | ---------------------------------------- | ------------ |
+| `--container` | Mode container | Deployment sederhana, lingkungan terisolasi | macOS, Linux |
+| `--native`    | Semua native   | Akses alat host (claude, gh)             | macOS, Linux |
+
+### Opsi
+
+| Flag                        | Deskripsi                                            |
+| --------------------------- | ---------------------------------------------------- |
+| `--lan`                     | Buka akses LAN (default: hanya localhost)            |
+| `--tailscale <host[:port]>` | Aktifkan Tailscale HTTPS                             |
+| `--no-auth`                 | Nonaktifkan autentikasi dasar                        |
+| `--port <port>`             | Port host (default: 7680, Windows: 7690)             |
+| `--fresh`                   | Paksa prompt password baru (abaikan config tersimpan) |
+| `--update`                  | Pembaruan otomatis dengan config tersimpan            |
+| `--version <ver>`           | Instal versi tertentu (dengan atau tanpa `v`)        |
+
+| Variabel Lingkungan | Deskripsi                                             |
+| -------------------- | ----------------------------------------------------- |
+| `WORKSPACE`          | Direktori host untuk mount (default: `./workspace`)   |
+| `TERMOTE_USER`       | Username autentikasi (default: otomatis dibuat)       |
+| `TERMOTE_PASS`       | Password autentikasi (default: otomatis dibuat)       |
+| `NO_AUTH`            | Atur ke `true` untuk menonaktifkan autentikasi        |
+
+### Mode Container (direkomendasikan untuk kemudahan)
+
+Skrip otomatis mendeteksi `podman` atau `docker` -- keduanya bekerja sama.
+
+```bash
+./scripts/termote.sh install container             # localhost dengan basic auth
+./scripts/termote.sh install container --no-auth   # localhost tanpa auth
+./scripts/termote.sh install container --lan       # Dapat diakses via LAN
+# Akses: http://localhost:7680
+
+# Direktori workspace khusus (dimount ke /workspace di container)
+WORKSPACE=~/projects ./scripts/termote.sh install container
+WORKSPACE=/path/to/code make install-container
+```
+
+> **Catatan keamanan**: Hindari mount langsung `$HOME` -- direktori sensitif seperti `.ssh`, `.gnupg` akan dapat diakses di container. Mount direktori proyek tertentu saja.
+
+### Native (direkomendasikan untuk akses binary host)
+
+Gunakan ketika Anda memerlukan akses ke binary host (claude, git, dll.):
+
+```bash
+# Linux
+sudo apt install ttyd tmux
+# Atau: sudo snap install ttyd
+./scripts/termote.sh install native
+
+# macOS
+brew install ttyd tmux go
+./scripts/termote.sh install native
+# Akses: http://localhost:7680
+```
+
+### Dengan Tailscale HTTPS (semua mode)
+
+Menggunakan `tailscale serve` untuk HTTPS otomatis (tanpa manajemen sertifikat manual):
+
+```bash
+# Hanya Tailscale (port default 443)
+./scripts/termote.sh install container --tailscale myhost.ts.net
+
+# Port khusus
+./scripts/termote.sh install native --tailscale myhost.ts.net:8765
+
+# Tailscale + akses LAN
+./scripts/termote.sh install container --tailscale myhost.ts.net --lan
+
+# Akses: https://myhost.ts.net (atau :8765 untuk port khusus)
+```
+
+### Hapus Instalasi
+
+```bash
+./scripts/termote.sh uninstall container   # Mode container
+./scripts/termote.sh uninstall native      # Mode native
+./scripts/termote.sh uninstall all         # Semuanya
+```
+
+### Pembaruan
+
+```bash
+# Opsi 1: Pembaruan otomatis dengan config tersimpan
+curl -fsSL .../get.sh | bash -s -- --update
+
+# Opsi 2: Jalankan ulang one-liner (bandingkan versi, tanya sebelum instal)
+curl -fsSL .../get.sh | bash
+
+# Opsi 3: Pembaruan manual
+./scripts/termote.sh uninstall [container|native]
+git pull origin main                    # Jika diinstal dari source
+./scripts/termote.sh install [container|native] [--lan] [--tailscale ...]
+```
+
+## Dukungan Platform
+
+| Platform | Container          | Native             | CLI Script  |
+| -------- | ------------------ | ------------------ | ----------- |
+| Linux    | ✓                  | ✓                  | termote.sh  |
+| macOS    | ✓                  | ✓                  | termote.sh  |
+| Windows  | ⚠️ (eksperimental) | ⚠️ (eksperimental) | termote.ps1 |
+
+> **⚠️ Dukungan Windows (Eksperimental)**: Dukungan Windows saat ini masih dalam tahap awal dan memerlukan pengujian lebih lanjut. Mode container memerlukan Docker Desktop, mode native memerlukan psmux. Silakan laporkan masalah di GitHub.
+
+### Mode Native Windows
+
+Mode native Windows menggunakan [psmux](https://github.com/psmux/psmux) (terminal multiplexer yang kompatibel dengan tmux untuk Windows):
+
+```powershell
+# Instal psmux
+winget install psmux
+
+# Jalankan Termote
+.\scripts\termote.ps1 install native
+.\scripts\termote.ps1 install container  # Atau mode container dengan Docker Desktop
+```
+
+## Penggunaan Mobile
+
+| Aksi                | Gestur              |
+| ------------------- | ------------------- |
+| Batal/interupsi     | Geser kiri (Ctrl+C) |
+| Tab completion      | Geser kanan         |
+| Riwayat ke atas     | Geser ke atas       |
+| Riwayat ke bawah    | Geser ke bawah      |
+| Tempel              | Tekan lama          |
+| Ukuran font         | Cubit masuk/keluar  |
+
+Toolbar virtual menyediakan: Tab, Esc, Ctrl, Shift, tombol panah, dan kombinasi tombol umum. Mendukung kombinasi Ctrl+Shift (tempel, salin). Beralih antara mode minimal dan diperluas untuk tombol tambahan (Home, End, Delete, dll.).
+
+## Struktur Proyek
+
+```
+termote/
+├── Makefile                # Perintah build/test/deploy
+├── Dockerfile              # Docker mode (tmux-api + ttyd)
+├── docker-compose.yml
+├── entrypoint.sh           # Docker entrypoint
+├── docs/                   # Dokumentasi
+│   └── images/screenshots/ # Tangkapan layar aplikasi
+├── pwa/                    # React PWA
+│   └── src/
+│       ├── components/
+│       ├── contexts/
+│       ├── hooks/
+│       ├── types/
+│       └── utils/
+├── tmux-api/               # Go server
+│   ├── main.go             # Entry point
+│   ├── serve.go            # Server (PWA, proxy, auth)
+│   └── tmux.go             # tmux API handlers
+├── scripts/
+│   ├── termote.sh          # Unix CLI (install/uninstall/health)
+│   ├── termote.ps1         # Windows PowerShell CLI
+│   ├── get.sh              # Unix online installer (curl | bash)
+│   └── get.ps1             # Windows online installer (irm | iex)
+├── tests/                  # Suite tes
+│   ├── test-termote.sh
+│   ├── test-termote.ps1    # Tes Windows
+│   ├── test-get.sh
+│   └── test-entrypoints.sh
+└── website/                # Situs docs Astro Starlight
+    └── src/content/docs/   # Dokumentasi MDX
+```
+
+## Pengembangan
+
+```bash
+make build          # Build PWA dan tmux-api
+make test           # Jalankan semua tes
+make health         # Periksa health service
+make clean          # Hentikan containers
+
+# Tes E2E (memerlukan server yang berjalan)
+./scripts/termote.sh install container  # Mulai server terlebih dahulu
+cd pwa && pnpm test:e2e       # Jalankan tes Playwright
+cd pwa && pnpm test:e2e:ui    # Jalankan dengan UI debugger
+```
+
+**Pengujian Manual:** Lihat [Daftar Periksa Self-Test](docs/self-test-checklist.md)
+
+## Pemecahan Masalah
+
+### Session tidak tersimpan
+
+- Periksa tmux: `tmux ls`
+- Verifikasi ttyd menggunakan flag `-A` (attach-or-create)
+
+### Error WebSocket
+
+- Periksa log tmux-api: `docker logs termote`
+- Verifikasi ttyd berjalan di port 7681
+
+### Masalah keyboard mobile
+
+- Pastikan viewport meta tag tersedia
+- Uji di perangkat nyata, bukan emulator
+
+### Mode native: proses tidak berjalan
+
+```bash
+ps aux | grep ttyd         # Periksa apakah ttyd berjalan
+ps aux | grep tmux-api     # Periksa apakah tmux-api berjalan
+lsof -i :7680              # Verifikasi port sedang digunakan
+```
+
+## Catatan Keamanan
+
+- **Default: hanya localhost** - tidak terbuka ke LAN kecuali menggunakan flag `--lan`
+- **Basic auth aktif secara default** - gunakan `--no-auth` untuk menonaktifkan di dev lokal
+- **Proteksi brute-force bawaan** - rate limiting (5 percobaan/menit per IP)
+- Gunakan HTTPS (Tailscale) untuk production
+- Batasi ke jaringan tepercaya/VPN
+
+## Lisensi
+
+MIT

--- a/README.ja.md
+++ b/README.ja.md
@@ -1,0 +1,453 @@
+<p align="center">
+  <img src="pwa/public/banner-readme.svg" alt="Termote" width="600" />
+</p>
+
+<p align="center">
+  <a href="https://github.com/lamngockhuong/termote/releases"><img src="https://img.shields.io/github/v/release/lamngockhuong/termote?style=flat-square&color=blue" alt="Release" /></a>
+  <a href="https://github.com/lamngockhuong/termote/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/lamngockhuong/termote/ci.yml?branch=main&style=flat-square&label=CI" alt="CI" /></a>
+  <a href="https://github.com/lamngockhuong/termote/blob/main/LICENSE"><img src="https://img.shields.io/github/license/lamngockhuong/termote?style=flat-square" alt="License" /></a>
+  <a href="https://ghcr.io/lamngockhuong/termote"><img src="https://img.shields.io/badge/GHCR-termote-blue?style=flat-square&logo=github" alt="GHCR" /></a>
+  <a href="https://hub.docker.com/r/lamngockhuong/termote"><img src="https://img.shields.io/docker/pulls/lamngockhuong/termote?style=flat-square&logo=docker" alt="Docker Pulls" /></a>
+</p>
+
+<p align="center">
+  <img src="https://img.shields.io/badge/Go-1.21-00ADD8?style=flat-square&logo=go&logoColor=white" alt="Go" />
+  <img src="https://img.shields.io/badge/React-19-61DAFB?style=flat-square&logo=react&logoColor=black" alt="React" />
+  <img src="https://img.shields.io/badge/TypeScript-5.9-3178C6?style=flat-square&logo=typescript&logoColor=white" alt="TypeScript" />
+  <img src="https://img.shields.io/badge/PWA-ready-5A0FC8?style=flat-square&logo=pwa&logoColor=white" alt="PWA" />
+</p>
+
+<p align="center">
+  <a href="https://launch.j2team.dev/products/termote?utm_source=badge-launched&utm_medium=badge&utm_campaign=badge-termote" target="_blank" rel="noopener noreferrer"><img src="https://launch.j2team.dev/badge/termote/dark" alt="Termote - Launched on J2TEAM Launch" width="170" height="36" loading="lazy" /></a>
+  &nbsp;
+  <a href="https://unikorn.vn/p/termote?ref=embed-termote" target="_blank"><img src="https://unikorn.vn/api/widgets/badge/termote?theme=dark" alt="Termote trên Unikorn.vn" width="170" height="42" /></a>
+</p>
+
+モバイル/デスクトップからPWA経由でCLIツール（Claude Code、GitHub Copilot、あらゆるターミナル）をリモート操作。
+
+> **Termote** = Terminal + Remote
+>
+> 🇬🇧 [English](README.md) | 🇻🇳 [Tiếng Việt](README.vi.md) | 🇨🇳 [简体中文](README.zh-CN.md) | 🇰🇷 [한국어](README.ko.md) | 🇪🇸 [Español](README.es.md) | 🇧🇷 [Português (BR)](README.pt-BR.md) | 🇫🇷 [Français](README.fr.md) | 🇩🇪 [Deutsch](README.de.md) | 🇷🇺 [Русский](README.ru.md) | 🇮🇩 [Bahasa Indonesia](README.id.md)
+
+## 機能
+
+- **セッション切り替え**: 作成/編集/削除が可能な複数のtmuxセッション
+- **セッションタブ**: ウィンドウをすばやく切り替えるための水平タブバー
+- **モバイル対応**: 仮想キーボードツールバー（Tab/Ctrl/Shift/矢印キー、展開可能）
+- **ジェスチャー操作**: スワイプでCtrl+C、Tab、履歴ナビゲーション
+- **コマンド履歴**: 検索機能付きの送信済みコマンド呼び出し
+- **クイックアクション**: よく使う操作（clear、cancel、exit）のフローティングメニュー
+- **接続インジケーター**: リアルタイムのサーバー状態表示と切断自動検出
+- **アップデートチェック**: GitHub releasesからの新バージョン自動通知
+- **PWA**: ホーム画面にインストール可能、オフライン対応
+- **永続セッション**: tmuxがセッションを維持
+- **折りたたみ可能なサイドバー**: トグル式セッションサイドバー付きデスクトップUI
+- **フルスクリーンモード**: 没入型ターミナル体験
+- **設定の永続化**: AES-256暗号化パスワードによるインストール設定の自動保存
+
+## スクリーンショット
+
+<p align="center">
+  <img src="docs/images/screenshots/mobile-terminal.png" alt="モバイルターミナル" width="280" />
+  &nbsp;&nbsp;
+  <img src="docs/images/screenshots/mobile-sidebar.png" alt="セッションサイドバー" width="280" />
+</p>
+
+## アーキテクチャ
+
+```mermaid
+flowchart TB
+    subgraph Client["クライアント (モバイル/デスクトップ)"]
+        PWA["PWA - React + TypeScript"]
+        Gestures["ジェスチャー操作"]
+        Keyboard["仮想キーボード"]
+    end
+
+    subgraph Server["tmux-api サーバー :7680"]
+        Static["静的ファイル"]
+        Proxy["WebSocket プロキシ"]
+        API["REST API /api/tmux/*"]
+        Auth["Basic認証"]
+    end
+
+    subgraph Backend["バックエンドサービス"]
+        ttyd["ttyd :7681"]
+        tmux["tmux"]
+        Shell["Shell"]
+        Tools["CLIツール"]
+    end
+
+    Gestures --> PWA
+    Keyboard --> PWA
+    PWA --> Static
+    PWA <--> Proxy
+    PWA --> API
+    Auth -.-> Static & Proxy & API
+    Proxy <--> ttyd
+    API --> tmux
+    ttyd --> tmux --> Shell --> Tools
+```
+
+## クイックスタート
+
+> 📖 **Termote初めてですか？** 詳しい手順と例については[はじめにガイド](docs/getting-started.md)をご覧ください。
+
+```bash
+./scripts/termote.sh                   # インタラクティブメニュー
+./scripts/termote.sh install container # コンテナモード (docker/podman)
+./scripts/termote.sh install native    # ネイティブモード (ホストツール)
+./scripts/termote.sh link              # 'termote' グローバルコマンドを作成
+make test                              # テストを実行
+```
+
+> `link`後は、どこからでも`termote`を使用可能: `termote health`, `termote install native --lan`
+
+> **ヒント**: [gum](https://github.com/charmbracelet/gum)をインストールすると、より美しいインタラクティブメニューが利用可能（オプション、bashフォールバックあり）
+
+## インストール
+
+### ワンライナー（推奨）
+
+**macOS/Linux:**
+
+```bash
+# ダウンロードしてインストール前に確認（デフォルトはnativeモード）
+curl -fsSL https://raw.githubusercontent.com/lamngockhuong/termote/main/scripts/get.sh | bash
+
+# 確認なしで自動インストール
+curl -fsSL .../get.sh | bash -s -- --yes
+
+# ダウンロードのみ（インストールなし）
+curl -fsSL .../get.sh | bash -s -- --download-only
+
+# 保存済み設定で自動アップデート
+curl -fsSL .../get.sh | bash -s -- --update
+
+# 特定バージョンをインストール
+curl -fsSL .../get.sh | bash -s -- --version 0.0.4
+
+# モードとオプションを明示的に指定
+curl -fsSL .../get.sh | bash -s -- --yes --container --lan
+curl -fsSL .../get.sh | bash -s -- --yes --native --tailscale myhost
+
+# 新しいパスワードを強制（保存済み設定を無視）
+curl -fsSL .../get.sh | bash -s -- --yes --container --fresh
+```
+
+**Windows (PowerShell):**
+
+> **注意:** システムでスクリプト実行が無効な場合、先に以下を実行してください:
+>
+> ```powershell
+> Set-ExecutionPolicy -Scope CurrentUser -ExecutionPolicy RemoteSigned
+> ```
+
+```powershell
+# ダウンロードしてインストール前に確認（デフォルトはnativeモード）
+irm https://raw.githubusercontent.com/lamngockhuong/termote/main/scripts/get.ps1 | iex
+
+# 確認なしで自動インストール
+$env:TERMOTE_AUTO_YES = "true"; irm .../get.ps1 | iex
+
+# モードを明示的に指定
+$env:TERMOTE_MODE = "container"; irm .../get.ps1 | iex
+
+# 保存済み設定で自動アップデート
+$env:TERMOTE_UPDATE = "true"; irm .../get.ps1 | iex
+```
+
+### Docker
+
+```bash
+# オールインワン（認証情報自動生成、ログ確認: docker logs termote）
+docker run -d --name termote -p 7680:7680 ghcr.io/lamngockhuong/termote:latest
+
+# カスタム認証情報
+docker run -d --name termote -p 7680:7680 \
+  -e TERMOTE_USER=admin -e TERMOTE_PASS=secret \
+  ghcr.io/lamngockhuong/termote:latest
+
+# 認証なし（ローカル開発のみ）
+docker run -d --name termote -p 7680:7680 \
+  -e NO_AUTH=true \
+  ghcr.io/lamngockhuong/termote:latest
+
+# 永続化用ボリューム付き
+docker run -d --name termote -p 7680:7680 \
+  -v termote-data:/home/termote \
+  ghcr.io/lamngockhuong/termote:latest
+
+# カスタムワークスペースディレクトリをマウント
+docker run -d --name termote -p 7680:7680 \
+  -v ~/projects:/workspace \
+  ghcr.io/lamngockhuong/termote:latest
+
+# Tailscale HTTPS付き（ホストにTailscaleが必要）
+docker run -d --name termote -p 7680:7680 \
+  -e TERMOTE_USER=admin -e TERMOTE_PASS=secret \
+  ghcr.io/lamngockhuong/termote:latest
+sudo tailscale serve --bg --https=443 http://127.0.0.1:7680
+# アクセス: https://your-hostname.tailnet-name.ts.net
+```
+
+### リリースから
+
+```bash
+# 最新リリースをダウンロード
+VERSION=$(curl -s https://api.github.com/repos/lamngockhuong/termote/releases/latest | grep tag_name | cut -d '"' -f4)
+wget https://github.com/lamngockhuong/termote/releases/download/${VERSION}/termote-${VERSION}.tar.gz
+tar xzf termote-${VERSION}.tar.gz
+cd termote-${VERSION#v}
+
+# インストール（インタラクティブメニューまたはモード指定）
+./scripts/termote.sh install
+./scripts/termote.sh install container
+```
+
+### ソースから
+
+```bash
+git clone https://github.com/lamngockhuong/termote.git
+cd termote
+./scripts/termote.sh install container
+```
+
+> **注**: `termote.sh`は`install`（ソースからビルド、利用可能な場合はビルド済みアーティファクトを使用）、`uninstall`、`health`コマンドをサポートする統合CLIです。
+
+## デプロイモード
+
+```mermaid
+flowchart LR
+    subgraph Container["コンテナモード"]
+        direction TB
+        C1["Docker/Podman"] --> C2["tmux-api :7680"] --> C3["ttyd :7681"] --> C4["tmux"]
+    end
+
+    subgraph Native["ネイティブモード"]
+        direction TB
+        N1["ホストシステム"] --> N2["tmux-api :7680"] --> N3["ttyd :7681"] --> N4["tmux + ホストツール"]
+    end
+
+    User["ユーザー"] --> Container & Native
+```
+
+| モード        | 説明             | ユースケース                     | プラットフォーム |
+| ------------- | ---------------- | ------------------------------- | ------------ |
+| `--container` | コンテナモード    | シンプルなデプロイ、隔離環境      | macOS, Linux |
+| `--native`    | 全てネイティブ    | ホストツールへのアクセス (claude, gh) | macOS, Linux |
+
+### オプション
+
+| フラグ                      | 説明                                            |
+| --------------------------- | ----------------------------------------------- |
+| `--lan`                     | LANに公開（デフォルト: localhostのみ）           |
+| `--tailscale <host[:port]>` | Tailscale HTTPSを有効化                         |
+| `--no-auth`                 | Basic認証を無効化                                |
+| `--port <port>`             | ホストポート（デフォルト: 7680、Windows: 7690）   |
+| `--fresh`                   | 新しいパスワードを強制（保存済み設定を無視）       |
+| `--update`                  | 保存済み設定で自動アップデート                    |
+| `--version <ver>`           | 特定バージョンをインストール（`v`有無どちらも可）  |
+
+| 環境変数         | 説明                                             |
+| ---------------- | ------------------------------------------------ |
+| `WORKSPACE`      | マウントするホストディレクトリ（デフォルト: `./workspace`） |
+| `TERMOTE_USER`   | Basic認証ユーザー名（デフォルト: 自動生成）       |
+| `TERMOTE_PASS`   | Basic認証パスワード（デフォルト: 自動生成）       |
+| `NO_AUTH`        | `true`に設定して認証を無効化                      |
+
+### コンテナモード（シンプルさ重視の推奨）
+
+スクリプトは`podman`または`docker`を自動検出 — どちらも同じように動作します。
+
+```bash
+./scripts/termote.sh install container             # localhostでbasic auth付き
+./scripts/termote.sh install container --no-auth   # localhostで認証なし
+./scripts/termote.sh install container --lan       # LANアクセス可能
+# アクセス: http://localhost:7680
+
+# カスタムワークスペースディレクトリ（コンテナ内の/workspaceにマウント）
+WORKSPACE=~/projects ./scripts/termote.sh install container
+WORKSPACE=/path/to/code make install-container
+```
+
+> **セキュリティ注意**: `$HOME`を直接マウントしないでください — `.ssh`、`.gnupg`などの機密ディレクトリがコンテナ内からアクセス可能になります。代わりに特定のプロジェクトディレクトリをマウントしてください。
+
+### ネイティブ（ホストバイナリアクセスの推奨）
+
+ホストバイナリ（claude、gitなど）へのアクセスが必要な場合に使用:
+
+```bash
+# Linux
+sudo apt install ttyd tmux
+# または: sudo snap install ttyd
+./scripts/termote.sh install native
+
+# macOS
+brew install ttyd tmux go
+./scripts/termote.sh install native
+# アクセス: http://localhost:7680
+```
+
+### Tailscale HTTPS付き（全モード）
+
+`tailscale serve`で自動HTTPS（手動の証明書管理不要）:
+
+```bash
+# Tailscaleのみ（デフォルトポート443）
+./scripts/termote.sh install container --tailscale myhost.ts.net
+
+# カスタムポート
+./scripts/termote.sh install native --tailscale myhost.ts.net:8765
+
+# Tailscale + LANアクセス可能
+./scripts/termote.sh install container --tailscale myhost.ts.net --lan
+
+# アクセス: https://myhost.ts.net（カスタムポートの場合は :8765）
+```
+
+### アンインストール
+
+```bash
+./scripts/termote.sh uninstall container   # コンテナモード
+./scripts/termote.sh uninstall native      # ネイティブモード
+./scripts/termote.sh uninstall all         # 全て
+```
+
+### アップデート
+
+```bash
+# 方法1: 保存済み設定で自動アップデート
+curl -fsSL .../get.sh | bash -s -- --update
+
+# 方法2: ワンライナーを再実行（バージョン比較、インストール前に確認）
+curl -fsSL .../get.sh | bash
+
+# 方法3: 手動アップデート
+./scripts/termote.sh uninstall [container|native]
+git pull origin main                    # ソースからインストールした場合
+./scripts/termote.sh install [container|native] [--lan] [--tailscale ...]
+```
+
+## プラットフォームサポート
+
+| プラットフォーム | コンテナ       | ネイティブ     | CLIスクリプト |
+| --------------- | -------------- | -------------- | ----------- |
+| Linux           | ✓              | ✓              | termote.sh  |
+| macOS           | ✓              | ✓              | termote.sh  |
+| Windows         | ⚠️ (実験的)     | ⚠️ (実験的)     | termote.ps1 |
+
+> **⚠️ Windowsサポート（実験的）**: Windowsサポートは現在初期段階であり、さらなるテストが必要です。コンテナモードにはDocker Desktopが、ネイティブモードにはpsmuxが必要です。問題はGitHubで報告してください。
+
+### Windows ネイティブモード
+
+Windowsネイティブモードは[psmux](https://github.com/psmux/psmux)（Windows用tmux互換ターミナルマルチプレクサ）を使用します:
+
+```powershell
+# psmuxをインストール
+winget install psmux
+
+# Termoteを実行
+.\scripts\termote.ps1 install native
+.\scripts\termote.ps1 install container  # またはDocker Desktopでコンテナモード
+```
+
+## モバイルでの使い方
+
+| 操作             | ジェスチャー        |
+| ---------------- | ------------------- |
+| キャンセル/中断   | 左スワイプ (Ctrl+C) |
+| Tab補完          | 右スワイプ          |
+| 履歴を上に        | 上スワイプ          |
+| 履歴を下に        | 下スワイプ          |
+| ペースト          | 長押し              |
+| フォントサイズ    | ピンチイン/アウト    |
+
+仮想ツールバーが提供するキー: Tab、Esc、Ctrl、Shift、矢印キー、よく使うキーの組み合わせ。Ctrl+Shiftの組み合わせ（ペースト、コピー）に対応。最小モードと展開モードの切り替えで追加キー（Home、End、Deleteなど）が利用可能。
+
+## プロジェクト構成
+
+```
+termote/
+├── Makefile                # ビルド/テスト/デプロイコマンド
+├── Dockerfile              # Dockerモード (tmux-api + ttyd)
+├── docker-compose.yml
+├── entrypoint.sh           # Dockerエントリーポイント
+├── docs/                   # ドキュメント
+│   └── images/screenshots/ # アプリのスクリーンショット
+├── pwa/                    # React PWA
+│   └── src/
+│       ├── components/
+│       ├── contexts/
+│       ├── hooks/
+│       ├── types/
+│       └── utils/
+├── tmux-api/               # Goサーバー
+│   ├── main.go             # エントリーポイント
+│   ├── serve.go            # サーバー (PWA, プロキシ, 認証)
+│   └── tmux.go             # tmux APIハンドラー
+├── scripts/
+│   ├── termote.sh          # Unix CLI (install/uninstall/health)
+│   ├── termote.ps1         # Windows PowerShell CLI
+│   ├── get.sh              # Unixオンラインインストーラー (curl | bash)
+│   └── get.ps1             # Windowsオンラインインストーラー (irm | iex)
+├── tests/                  # テストスイート
+│   ├── test-termote.sh
+│   ├── test-termote.ps1    # Windowsテスト
+│   ├── test-get.sh
+│   └── test-entrypoints.sh
+└── website/                # Astro Starlightドキュメントサイト
+    └── src/content/docs/   # MDXドキュメント
+```
+
+## 開発
+
+```bash
+make build          # PWAとtmux-apiをビルド
+make test           # 全テストを実行
+make health         # サービスのヘルスチェック
+make clean          # コンテナを停止
+
+# E2Eテスト（実行中のサーバーが必要）
+./scripts/termote.sh install container  # 先にサーバーを起動
+cd pwa && pnpm test:e2e       # Playwrightテストを実行
+cd pwa && pnpm test:e2e:ui    # UIデバッガーで実行
+```
+
+**手動テスト:** [セルフテストチェックリスト](docs/self-test-checklist.md)を参照
+
+## トラブルシューティング
+
+### セッションが永続化されない
+
+- tmuxを確認: `tmux ls`
+- ttydが`-A`フラグ（attach-or-create）を使用しているか確認
+
+### WebSocketエラー
+
+- tmux-apiのログを確認: `docker logs termote`
+- ttydがポート7681で動作しているか確認
+
+### モバイルキーボードの問題
+
+- viewportメタタグが存在するか確認
+- エミュレーターではなく実機でテスト
+
+### ネイティブモード: プロセスが起動しない
+
+```bash
+ps aux | grep ttyd         # ttydが実行中か確認
+ps aux | grep tmux-api     # tmux-apiが実行中か確認
+lsof -i :7680              # ポートが使用中か確認
+```
+
+## セキュリティに関する注意
+
+- **デフォルト: localhostのみ** - `--lan`フラグを使用しない限りLANに公開されません
+- **Basic認証はデフォルトで有効** - ローカル開発では`--no-auth`で無効化
+- **ブルートフォース攻撃防止機能内蔵** - レート制限（IPあたり5回/分）
+- 本番環境ではHTTPS（Tailscale）を使用
+- 信頼できるネットワーク/VPNに制限
+
+## ライセンス
+
+MIT

--- a/README.ko.md
+++ b/README.ko.md
@@ -1,0 +1,453 @@
+<p align="center">
+  <img src="pwa/public/banner-readme.svg" alt="Termote" width="600" />
+</p>
+
+<p align="center">
+  <a href="https://github.com/lamngockhuong/termote/releases"><img src="https://img.shields.io/github/v/release/lamngockhuong/termote?style=flat-square&color=blue" alt="Release" /></a>
+  <a href="https://github.com/lamngockhuong/termote/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/lamngockhuong/termote/ci.yml?branch=main&style=flat-square&label=CI" alt="CI" /></a>
+  <a href="https://github.com/lamngockhuong/termote/blob/main/LICENSE"><img src="https://img.shields.io/github/license/lamngockhuong/termote?style=flat-square" alt="License" /></a>
+  <a href="https://ghcr.io/lamngockhuong/termote"><img src="https://img.shields.io/badge/GHCR-termote-blue?style=flat-square&logo=github" alt="GHCR" /></a>
+  <a href="https://hub.docker.com/r/lamngockhuong/termote"><img src="https://img.shields.io/docker/pulls/lamngockhuong/termote?style=flat-square&logo=docker" alt="Docker Pulls" /></a>
+</p>
+
+<p align="center">
+  <img src="https://img.shields.io/badge/Go-1.21-00ADD8?style=flat-square&logo=go&logoColor=white" alt="Go" />
+  <img src="https://img.shields.io/badge/React-19-61DAFB?style=flat-square&logo=react&logoColor=black" alt="React" />
+  <img src="https://img.shields.io/badge/TypeScript-5.9-3178C6?style=flat-square&logo=typescript&logoColor=white" alt="TypeScript" />
+  <img src="https://img.shields.io/badge/PWA-ready-5A0FC8?style=flat-square&logo=pwa&logoColor=white" alt="PWA" />
+</p>
+
+<p align="center">
+  <a href="https://launch.j2team.dev/products/termote?utm_source=badge-launched&utm_medium=badge&utm_campaign=badge-termote" target="_blank" rel="noopener noreferrer"><img src="https://launch.j2team.dev/badge/termote/dark" alt="Termote - Launched on J2TEAM Launch" width="170" height="36" loading="lazy" /></a>
+  &nbsp;
+  <a href="https://unikorn.vn/p/termote?ref=embed-termote" target="_blank"><img src="https://unikorn.vn/api/widgets/badge/termote?theme=dark" alt="Termote trên Unikorn.vn" width="170" height="42" /></a>
+</p>
+
+모바일/데스크톱에서 PWA를 통해 CLI 도구(Claude Code, GitHub Copilot, 모든 터미널)를 원격 제어.
+
+> **Termote** = Terminal + Remote
+>
+> 🇬🇧 [English](README.md) | 🇻🇳 [Tiếng Việt](README.vi.md) | 🇨🇳 [简体中文](README.zh-CN.md) | 🇯🇵 [日本語](README.ja.md) | 🇪🇸 [Español](README.es.md) | 🇧🇷 [Português (BR)](README.pt-BR.md) | 🇫🇷 [Français](README.fr.md) | 🇩🇪 [Deutsch](README.de.md) | 🇷🇺 [Русский](README.ru.md) | 🇮🇩 [Bahasa Indonesia](README.id.md)
+
+## 기능
+
+- **세션 전환**: 생성/편집/삭제가 가능한 여러 tmux 세션
+- **세션 탭**: 빠른 창 전환을 위한 가로 탭 바
+- **모바일 친화적**: 가상 키보드 툴바 (Tab/Ctrl/Shift/방향키, 확장 가능)
+- **제스처 지원**: 스와이프로 Ctrl+C, Tab, 히스토리 탐색
+- **명령 히스토리**: 검색 기능으로 이전에 전송한 명령 재호출
+- **빠른 작업**: 자주 쓰는 작업(clear, cancel, exit)을 위한 플로팅 메뉴
+- **연결 표시기**: 실시간 서버 상태 및 연결 끊김 자동 감지
+- **업데이트 확인**: GitHub releases에서 새 버전 자동 알림
+- **PWA**: 홈 화면에 설치 가능, 오프라인 지원
+- **영구 세션**: tmux가 세션을 유지
+- **접을 수 있는 사이드바**: 토글 가능한 세션 사이드바가 있는 데스크톱 UI
+- **전체 화면 모드**: 몰입형 터미널 경험
+- **설정 저장**: AES-256 암호화 비밀번호로 설치 설정 자동 저장
+
+## 스크린샷
+
+<p align="center">
+  <img src="docs/images/screenshots/mobile-terminal.png" alt="모바일 터미널" width="280" />
+  &nbsp;&nbsp;
+  <img src="docs/images/screenshots/mobile-sidebar.png" alt="세션 사이드바" width="280" />
+</p>
+
+## 아키텍처
+
+```mermaid
+flowchart TB
+    subgraph Client["클라이언트 (모바일/데스크톱)"]
+        PWA["PWA - React + TypeScript"]
+        Gestures["제스처 컨트롤"]
+        Keyboard["가상 키보드"]
+    end
+
+    subgraph Server["tmux-api 서버 :7680"]
+        Static["정적 파일"]
+        Proxy["WebSocket 프록시"]
+        API["REST API /api/tmux/*"]
+        Auth["Basic Auth"]
+    end
+
+    subgraph Backend["백엔드 서비스"]
+        ttyd["ttyd :7681"]
+        tmux["tmux"]
+        Shell["Shell"]
+        Tools["CLI 도구"]
+    end
+
+    Gestures --> PWA
+    Keyboard --> PWA
+    PWA --> Static
+    PWA <--> Proxy
+    PWA --> API
+    Auth -.-> Static & Proxy & API
+    Proxy <--> ttyd
+    API --> tmux
+    ttyd --> tmux --> Shell --> Tools
+```
+
+## 빠른 시작
+
+> 📖 **Termote가 처음이신가요?** 예제와 함께하는 완전한 안내는 [시작 가이드](docs/getting-started.md)를 확인하세요.
+
+```bash
+./scripts/termote.sh                   # 대화형 메뉴
+./scripts/termote.sh install container # 컨테이너 모드 (docker/podman)
+./scripts/termote.sh install native    # 네이티브 모드 (호스트 도구)
+./scripts/termote.sh link              # 'termote' 글로벌 명령 생성
+make test                              # 테스트 실행
+```
+
+> `link` 이후 어디서든 `termote` 사용 가능: `termote health`, `termote install native --lan`
+>
+> **팁**: 향상된 대화형 메뉴를 위해 [gum](https://github.com/charmbracelet/gum) 설치 (선택 사항, bash 폴백 가능)
+
+## 설치
+
+### 한 줄 명령 (권장)
+
+**macOS/Linux:**
+
+```bash
+# 다운로드 후 설치 전 확인 (기본값: native 모드)
+curl -fsSL https://raw.githubusercontent.com/lamngockhuong/termote/main/scripts/get.sh | bash
+
+# 확인 없이 자동 설치
+curl -fsSL .../get.sh | bash -s -- --yes
+
+# 다운로드만 (설치 안 함)
+curl -fsSL .../get.sh | bash -s -- --download-only
+
+# 저장된 설정으로 자동 업데이트
+curl -fsSL .../get.sh | bash -s -- --update
+
+# 특정 버전 설치
+curl -fsSL .../get.sh | bash -s -- --version 0.0.4
+
+# 모드와 옵션을 명시적으로 지정
+curl -fsSL .../get.sh | bash -s -- --yes --container --lan
+curl -fsSL .../get.sh | bash -s -- --yes --native --tailscale myhost
+
+# 새 비밀번호 강제 입력 (저장된 설정 무시)
+curl -fsSL .../get.sh | bash -s -- --yes --container --fresh
+```
+
+**Windows (PowerShell):**
+
+> **참고:** 시스템에서 스크립트 실행이 비활성화된 경우, 먼저 이 명령을 실행하세요:
+>
+> ```powershell
+> Set-ExecutionPolicy -Scope CurrentUser -ExecutionPolicy RemoteSigned
+> ```
+
+```powershell
+# 다운로드 후 설치 전 확인 (기본값: native 모드)
+irm https://raw.githubusercontent.com/lamngockhuong/termote/main/scripts/get.ps1 | iex
+
+# 확인 없이 자동 설치
+$env:TERMOTE_AUTO_YES = "true"; irm .../get.ps1 | iex
+
+# 모드를 명시적으로 지정
+$env:TERMOTE_MODE = "container"; irm .../get.ps1 | iex
+
+# 저장된 설정으로 자동 업데이트
+$env:TERMOTE_UPDATE = "true"; irm .../get.ps1 | iex
+```
+
+### Docker
+
+```bash
+# 올인원 (자격 증명 자동 생성, 로그 확인: docker logs termote)
+docker run -d --name termote -p 7680:7680 ghcr.io/lamngockhuong/termote:latest
+
+# 사용자 지정 자격 증명
+docker run -d --name termote -p 7680:7680 \
+  -e TERMOTE_USER=admin -e TERMOTE_PASS=secret \
+  ghcr.io/lamngockhuong/termote:latest
+
+# 인증 없음 (로컬 개발 전용)
+docker run -d --name termote -p 7680:7680 \
+  -e NO_AUTH=true \
+  ghcr.io/lamngockhuong/termote:latest
+
+# 영구 저장을 위한 볼륨 사용
+docker run -d --name termote -p 7680:7680 \
+  -v termote-data:/home/termote \
+  ghcr.io/lamngockhuong/termote:latest
+
+# 사용자 지정 workspace 디렉토리 마운트
+docker run -d --name termote -p 7680:7680 \
+  -v ~/projects:/workspace \
+  ghcr.io/lamngockhuong/termote:latest
+
+# Tailscale HTTPS 사용 (호스트에 Tailscale 필요)
+docker run -d --name termote -p 7680:7680 \
+  -e TERMOTE_USER=admin -e TERMOTE_PASS=secret \
+  ghcr.io/lamngockhuong/termote:latest
+sudo tailscale serve --bg --https=443 http://127.0.0.1:7680
+# 접속: https://your-hostname.tailnet-name.ts.net
+```
+
+### Release에서 설치
+
+```bash
+# 최신 릴리스 다운로드
+VERSION=$(curl -s https://api.github.com/repos/lamngockhuong/termote/releases/latest | grep tag_name | cut -d '"' -f4)
+wget https://github.com/lamngockhuong/termote/releases/download/${VERSION}/termote-${VERSION}.tar.gz
+tar xzf termote-${VERSION}.tar.gz
+cd termote-${VERSION#v}
+
+# 설치 (대화형 메뉴 또는 모드 지정)
+./scripts/termote.sh install
+./scripts/termote.sh install container
+```
+
+### 소스에서 설치
+
+```bash
+git clone https://github.com/lamngockhuong/termote.git
+cd termote
+./scripts/termote.sh install container
+```
+
+> **참고**: `termote.sh`는 `install` (소스에서 빌드, 가능한 경우 사전 빌드된 아티팩트 사용), `uninstall`, `health` 명령을 지원하는 통합 CLI입니다.
+
+## 배포 모드
+
+```mermaid
+flowchart LR
+    subgraph Container["컨테이너 모드"]
+        direction TB
+        C1["Docker/Podman"] --> C2["tmux-api :7680"] --> C3["ttyd :7681"] --> C4["tmux"]
+    end
+
+    subgraph Native["네이티브 모드"]
+        direction TB
+        N1["호스트 시스템"] --> N2["tmux-api :7680"] --> N3["ttyd :7681"] --> N4["tmux + 호스트 도구"]
+    end
+
+    User["사용자"] --> Container & Native
+```
+
+| 모드          | 설명            | 사용 사례                         | 플랫폼       |
+| ------------- | -------------- | ------------------------------- | ------------ |
+| `--container` | 컨테이너 모드    | 간단한 배포, 격리된 환경            | macOS, Linux |
+| `--native`    | 전체 네이티브    | 호스트 도구 접근 (claude, gh)      | macOS, Linux |
+
+### 옵션
+
+| 플래그                      | 설명                                            |
+| --------------------------- | ----------------------------------------------- |
+| `--lan`                     | LAN에 노출 (기본값: localhost만)                  |
+| `--tailscale <host[:port]>` | Tailscale HTTPS 활성화                           |
+| `--no-auth`                 | 기본 인증 비활성화                                |
+| `--port <port>`             | 호스트 포트 (기본값: 7680, Windows: 7690)         |
+| `--fresh`                   | 새 비밀번호 강제 입력 (저장된 설정 무시)            |
+| `--update`                  | 저장된 설정으로 자동 업데이트                       |
+| `--version <ver>`           | 특정 버전 설치 (`v` 포함/미포함 모두 가능)          |
+
+| 환경 변수          | 설명                                             |
+| -------------------- | ------------------------------------------------ |
+| `WORKSPACE`          | 마운트할 호스트 디렉토리 (기본값: `./workspace`)    |
+| `TERMOTE_USER`       | Basic auth 사용자 이름 (기본값: 자동 생성)          |
+| `TERMOTE_PASS`       | Basic auth 비밀번호 (기본값: 자동 생성)             |
+| `NO_AUTH`            | `true`로 설정하여 인증 비활성화                     |
+
+### 컨테이너 모드 (간편한 사용을 위해 권장)
+
+스크립트가 `podman` 또는 `docker`를 자동 감지합니다 -- 둘 다 동일하게 작동합니다.
+
+```bash
+./scripts/termote.sh install container             # localhost + basic auth
+./scripts/termote.sh install container --no-auth   # localhost + 인증 없음
+./scripts/termote.sh install container --lan       # LAN 접근 가능
+# 접속: http://localhost:7680
+
+# 사용자 지정 workspace 디렉토리 (컨테이너 내 /workspace에 마운트)
+WORKSPACE=~/projects ./scripts/termote.sh install container
+WORKSPACE=/path/to/code make install-container
+```
+
+> **보안 참고**: `$HOME`을 직접 마운트하지 마세요 -- `.ssh`, `.gnupg` 같은 민감한 디렉토리가 컨테이너에서 접근 가능해집니다. 대신 특정 프로젝트 디렉토리를 마운트하세요.
+
+### 네이티브 (호스트 바이너리 접근을 위해 권장)
+
+호스트 바이너리(claude, git 등)에 접근이 필요할 때 사용:
+
+```bash
+# Linux
+sudo apt install ttyd tmux
+# 또는: sudo snap install ttyd
+./scripts/termote.sh install native
+
+# macOS
+brew install ttyd tmux go
+./scripts/termote.sh install native
+# 접속: http://localhost:7680
+```
+
+### Tailscale HTTPS 사용 (모든 모드)
+
+자동 HTTPS를 위해 `tailscale serve`를 사용합니다 (수동 인증서 관리 불필요):
+
+```bash
+# Tailscale만 (기본 포트 443)
+./scripts/termote.sh install container --tailscale myhost.ts.net
+
+# 사용자 지정 포트
+./scripts/termote.sh install native --tailscale myhost.ts.net:8765
+
+# Tailscale + LAN 접근 가능
+./scripts/termote.sh install container --tailscale myhost.ts.net --lan
+
+# 접속: https://myhost.ts.net (또는 사용자 지정 포트의 경우 :8765)
+```
+
+### 제거
+
+```bash
+./scripts/termote.sh uninstall container   # 컨테이너 모드
+./scripts/termote.sh uninstall native      # 네이티브 모드
+./scripts/termote.sh uninstall all         # 전체
+```
+
+### 업데이트
+
+```bash
+# 방법 1: 저장된 설정으로 자동 업데이트
+curl -fsSL .../get.sh | bash -s -- --update
+
+# 방법 2: 한 줄 명령 재실행 (버전 비교, 설치 전 확인)
+curl -fsSL .../get.sh | bash
+
+# 방법 3: 수동 업데이트
+./scripts/termote.sh uninstall [container|native]
+git pull origin main                    # 소스에서 설치한 경우
+./scripts/termote.sh install [container|native] [--lan] [--tailscale ...]
+```
+
+## 플랫폼 지원
+
+| 플랫폼   | 컨테이너       | 네이티브       | CLI 스크립트 |
+| -------- | -------------- | -------------- | ----------- |
+| Linux    | ✓              | ✓              | termote.sh  |
+| macOS    | ✓              | ✓              | termote.sh  |
+| Windows  | ⚠️ (실험적)     | ⚠️ (실험적)     | termote.ps1 |
+
+> **⚠️ Windows 지원 (실험적)**: Windows 지원은 현재 초기 단계이며 추가 테스트가 필요합니다. 컨테이너 모드는 Docker Desktop이 필요하고, 네이티브 모드는 psmux가 필요합니다. GitHub에서 이슈를 보고해 주세요.
+
+### Windows 네이티브 모드
+
+Windows 네이티브 모드는 [psmux](https://github.com/psmux/psmux) (Windows용 tmux 호환 터미널 멀티플렉서)를 사용합니다:
+
+```powershell
+# psmux 설치
+winget install psmux
+
+# Termote 실행
+.\scripts\termote.ps1 install native
+.\scripts\termote.ps1 install container  # 또는 Docker Desktop으로 컨테이너 모드
+```
+
+## 모바일 사용법
+
+| 동작           | 제스처              |
+| -------------- | ------------------- |
+| 취소/중단       | 왼쪽 스와이프 (Ctrl+C) |
+| Tab 자동 완성   | 오른쪽 스와이프       |
+| 히스토리 위로   | 위로 스와이프         |
+| 히스토리 아래로 | 아래로 스와이프       |
+| 붙여넣기       | 길게 누르기           |
+| 글꼴 크기      | 핀치 인/아웃          |
+
+가상 툴바 제공: Tab, Esc, Ctrl, Shift, 방향키 및 일반 키 조합. Ctrl+Shift 조합(붙여넣기, 복사) 지원. 추가 키(Home, End, Delete 등)를 위해 최소 모드와 확장 모드 간 전환 가능.
+
+## 프로젝트 구조
+
+```
+termote/
+├── Makefile                # 빌드/테스트/배포 명령
+├── Dockerfile              # Docker 모드 (tmux-api + ttyd)
+├── docker-compose.yml
+├── entrypoint.sh           # Docker 엔트리포인트
+├── docs/                   # 문서
+│   └── images/screenshots/ # 앱 스크린샷
+├── pwa/                    # React PWA
+│   └── src/
+│       ├── components/
+│       ├── contexts/
+│       ├── hooks/
+│       ├── types/
+│       └── utils/
+├── tmux-api/               # Go 서버
+│   ├── main.go             # 엔트리 포인트
+│   ├── serve.go            # 서버 (PWA, 프록시, 인증)
+│   └── tmux.go             # tmux API 핸들러
+├── scripts/
+│   ├── termote.sh          # Unix CLI (install/uninstall/health)
+│   ├── termote.ps1         # Windows PowerShell CLI
+│   ├── get.sh              # Unix 온라인 설치기 (curl | bash)
+│   └── get.ps1             # Windows 온라인 설치기 (irm | iex)
+├── tests/                  # 테스트 모음
+│   ├── test-termote.sh
+│   ├── test-termote.ps1    # Windows 테스트
+│   ├── test-get.sh
+│   └── test-entrypoints.sh
+└── website/                # Astro Starlight 문서 사이트
+    └── src/content/docs/   # MDX 문서
+```
+
+## 개발
+
+```bash
+make build          # PWA와 tmux-api 빌드
+make test           # 모든 테스트 실행
+make health         # 서비스 상태 확인
+make clean          # 컨테이너 중지
+
+# E2E 테스트 (실행 중인 서버 필요)
+./scripts/termote.sh install container  # 먼저 서버 시작
+cd pwa && pnpm test:e2e       # Playwright 테스트 실행
+cd pwa && pnpm test:e2e:ui    # UI 디버거로 실행
+```
+
+**수동 테스트:** [자체 테스트 체크리스트](docs/self-test-checklist.md) 참조
+
+## 문제 해결
+
+### 세션이 유지되지 않음
+
+- tmux 확인: `tmux ls`
+- ttyd가 `-A` 플래그(attach-or-create)를 사용하는지 확인
+
+### WebSocket 오류
+
+- tmux-api 로그 확인: `docker logs termote`
+- ttyd가 포트 7681에서 실행 중인지 확인
+
+### 모바일 키보드 문제
+
+- viewport meta 태그가 있는지 확인
+- 에뮬레이터가 아닌 실제 기기에서 테스트
+
+### 네이티브 모드: 프로세스가 시작되지 않음
+
+```bash
+ps aux | grep ttyd         # ttyd 실행 중인지 확인
+ps aux | grep tmux-api     # tmux-api 실행 중인지 확인
+lsof -i :7680              # 포트 사용 중인지 확인
+```
+
+## 보안 참고
+
+- **기본값: localhost만** - `--lan` 플래그를 사용하지 않으면 LAN에 노출되지 않음
+- **기본 인증 기본 활성화** - 로컬 개발 시 `--no-auth`로 비활성화
+- **내장 무차별 대입 방지** - 속도 제한 (IP당 5회 시도/분)
+- 프로덕션에는 HTTPS(Tailscale) 사용
+- 신뢰할 수 있는 네트워크/VPN으로 제한
+
+## 라이선스
+
+MIT

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Remote control CLI tools (Claude Code, GitHub Copilot, any terminal) from mobile
 
 > **Termote** = Terminal + Remote
 >
-> [Tiếng Việt](README.vi.md)
+> 🇻🇳 [Tiếng Việt](README.vi.md) | 🇨🇳 [简体中文](README.zh-CN.md) | 🇯🇵 [日本語](README.ja.md) | 🇰🇷 [한국어](README.ko.md) | 🇪🇸 [Español](README.es.md) | 🇧🇷 [Português (BR)](README.pt-BR.md) | 🇫🇷 [Français](README.fr.md) | 🇩🇪 [Deutsch](README.de.md) | 🇷🇺 [Русский](README.ru.md) | 🇮🇩 [Bahasa Indonesia](README.id.md)
 
 ## Features
 

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -1,0 +1,453 @@
+<p align="center">
+  <img src="pwa/public/banner-readme.svg" alt="Termote" width="600" />
+</p>
+
+<p align="center">
+  <a href="https://github.com/lamngockhuong/termote/releases"><img src="https://img.shields.io/github/v/release/lamngockhuong/termote?style=flat-square&color=blue" alt="Release" /></a>
+  <a href="https://github.com/lamngockhuong/termote/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/lamngockhuong/termote/ci.yml?branch=main&style=flat-square&label=CI" alt="CI" /></a>
+  <a href="https://github.com/lamngockhuong/termote/blob/main/LICENSE"><img src="https://img.shields.io/github/license/lamngockhuong/termote?style=flat-square" alt="License" /></a>
+  <a href="https://ghcr.io/lamngockhuong/termote"><img src="https://img.shields.io/badge/GHCR-termote-blue?style=flat-square&logo=github" alt="GHCR" /></a>
+  <a href="https://hub.docker.com/r/lamngockhuong/termote"><img src="https://img.shields.io/docker/pulls/lamngockhuong/termote?style=flat-square&logo=docker" alt="Docker Pulls" /></a>
+</p>
+
+<p align="center">
+  <img src="https://img.shields.io/badge/Go-1.21-00ADD8?style=flat-square&logo=go&logoColor=white" alt="Go" />
+  <img src="https://img.shields.io/badge/React-19-61DAFB?style=flat-square&logo=react&logoColor=black" alt="React" />
+  <img src="https://img.shields.io/badge/TypeScript-5.9-3178C6?style=flat-square&logo=typescript&logoColor=white" alt="TypeScript" />
+  <img src="https://img.shields.io/badge/PWA-ready-5A0FC8?style=flat-square&logo=pwa&logoColor=white" alt="PWA" />
+</p>
+
+<p align="center">
+  <a href="https://launch.j2team.dev/products/termote?utm_source=badge-launched&utm_medium=badge&utm_campaign=badge-termote" target="_blank" rel="noopener noreferrer"><img src="https://launch.j2team.dev/badge/termote/dark" alt="Termote - Launched on J2TEAM Launch" width="170" height="36" loading="lazy" /></a>
+  &nbsp;
+  <a href="https://unikorn.vn/p/termote?ref=embed-termote" target="_blank"><img src="https://unikorn.vn/api/widgets/badge/termote?theme=dark" alt="Termote trên Unikorn.vn" width="170" height="42" /></a>
+</p>
+
+Controle remotamente ferramentas CLI (Claude Code, GitHub Copilot, qualquer terminal) de dispositivos moveis/desktop via PWA.
+
+> **Termote** = Terminal + Remote
+>
+> 🇬🇧 [English](README.md) | 🇻🇳 [Tiếng Việt](README.vi.md) | 🇨🇳 [简体中文](README.zh-CN.md) | 🇯🇵 [日本語](README.ja.md) | 🇰🇷 [한국어](README.ko.md) | 🇪🇸 [Español](README.es.md) | 🇫🇷 [Français](README.fr.md) | 🇩🇪 [Deutsch](README.de.md) | 🇷🇺 [Русский](README.ru.md) | 🇮🇩 [Bahasa Indonesia](README.id.md)
+
+## Funcionalidades
+
+- **Alternancia de sessions**: Multiplas tmux sessions com criar/editar/excluir
+- **Abas de sessions**: Barra de abas horizontal para troca rapida entre janelas
+- **Otimizado para mobile**: Barra de teclado virtual (Tab/Ctrl/Shift/setas, expansivel)
+- **Suporte a gestos**: Deslizar para Ctrl+C, Tab, navegacao no historico
+- **Historico de comandos**: Recuperar comandos enviados anteriormente com busca
+- **Acoes rapidas**: Menu flutuante para operacoes comuns (clear, cancel, exit)
+- **Indicador de conexao**: Status do servidor em tempo real com deteccao automatica de desconexao
+- **Verificador de atualizacao**: Notificacao automatica de nova versao do GitHub releases
+- **PWA**: Instalavel na tela inicial, funciona offline
+- **Sessions persistentes**: tmux mantem as sessions ativas
+- **Barra lateral recolhivel**: Interface desktop com barra lateral de sessions alternavel
+- **Modo tela cheia**: Experiencia imersiva de terminal
+- **Persistencia de configuracao**: Salvamento automatico das configuracoes com senha criptografada AES-256
+
+## Capturas de Tela
+
+<p align="center">
+  <img src="docs/images/screenshots/mobile-terminal.png" alt="Terminal Mobile" width="280" />
+  &nbsp;&nbsp;
+  <img src="docs/images/screenshots/mobile-sidebar.png" alt="Barra Lateral de Sessions" width="280" />
+</p>
+
+## Arquitetura
+
+```mermaid
+flowchart TB
+    subgraph Client["Cliente (Mobile/Desktop)"]
+        PWA["PWA - React + TypeScript"]
+        Gestures["Controles por Gestos"]
+        Keyboard["Teclado Virtual"]
+    end
+
+    subgraph Server["tmux-api Server :7680"]
+        Static["Static Files"]
+        Proxy["WebSocket Proxy"]
+        API["REST API /api/tmux/*"]
+        Auth["Basic Auth"]
+    end
+
+    subgraph Backend["Backend Services"]
+        ttyd["ttyd :7681"]
+        tmux["tmux"]
+        Shell["Shell"]
+        Tools["CLI Tools"]
+    end
+
+    Gestures --> PWA
+    Keyboard --> PWA
+    PWA --> Static
+    PWA <--> Proxy
+    PWA --> API
+    Auth -.-> Static & Proxy & API
+    Proxy <--> ttyd
+    API --> tmux
+    ttyd --> tmux --> Shell --> Tools
+```
+
+## Inicio Rapido
+
+> 📖 **Novo no Termote?** Confira o [Guia de Inicio](docs/getting-started.md) para um passo a passo completo com exemplos.
+
+```bash
+./scripts/termote.sh                   # Menu interativo
+./scripts/termote.sh install container # Modo container (docker/podman)
+./scripts/termote.sh install native    # Modo nativo (ferramentas do host)
+./scripts/termote.sh link              # Criar comando global 'termote'
+make test                              # Executar testes
+```
+
+> Apos o `link`, use `termote` de qualquer lugar: `termote health`, `termote install native --lan`
+
+> **Dica**: Instale o [gum](https://github.com/charmbracelet/gum) para menus interativos aprimorados (opcional, fallback bash disponivel)
+
+## Instalacao
+
+### Uma linha (recomendado)
+
+**macOS/Linux:**
+
+```bash
+# Baixar e perguntar antes de instalar (padrao: modo nativo)
+curl -fsSL https://raw.githubusercontent.com/lamngockhuong/termote/main/scripts/get.sh | bash
+
+# Instalar automaticamente sem perguntar
+curl -fsSL .../get.sh | bash -s -- --yes
+
+# Apenas baixar (sem instalar)
+curl -fsSL .../get.sh | bash -s -- --download-only
+
+# Atualizar automaticamente com config salva
+curl -fsSL .../get.sh | bash -s -- --update
+
+# Instalar versao especifica
+curl -fsSL .../get.sh | bash -s -- --version 0.0.4
+
+# Com modo e opcoes explicitas
+curl -fsSL .../get.sh | bash -s -- --yes --container --lan
+curl -fsSL .../get.sh | bash -s -- --yes --native --tailscale myhost
+
+# Forcar nova senha (ignorar config salva)
+curl -fsSL .../get.sh | bash -s -- --yes --container --fresh
+```
+
+**Windows (PowerShell):**
+
+> **Nota:** Se a execucao de scripts estiver desabilitada no seu sistema, execute isto primeiro:
+>
+> ```powershell
+> Set-ExecutionPolicy -Scope CurrentUser -ExecutionPolicy RemoteSigned
+> ```
+
+```powershell
+# Baixar e perguntar antes de instalar (padrao: modo nativo)
+irm https://raw.githubusercontent.com/lamngockhuong/termote/main/scripts/get.ps1 | iex
+
+# Instalar automaticamente sem perguntar
+$env:TERMOTE_AUTO_YES = "true"; irm .../get.ps1 | iex
+
+# Com modo explicito
+$env:TERMOTE_MODE = "container"; irm .../get.ps1 | iex
+
+# Atualizar automaticamente com config salva
+$env:TERMOTE_UPDATE = "true"; irm .../get.ps1 | iex
+```
+
+### Docker
+
+```bash
+# Tudo em um (gera credenciais automaticamente, veja logs: docker logs termote)
+docker run -d --name termote -p 7680:7680 ghcr.io/lamngockhuong/termote:latest
+
+# Com credenciais personalizadas
+docker run -d --name termote -p 7680:7680 \
+  -e TERMOTE_USER=admin -e TERMOTE_PASS=secret \
+  ghcr.io/lamngockhuong/termote:latest
+
+# Sem autenticacao (apenas dev local)
+docker run -d --name termote -p 7680:7680 \
+  -e NO_AUTH=true \
+  ghcr.io/lamngockhuong/termote:latest
+
+# Com volume para persistencia
+docker run -d --name termote -p 7680:7680 \
+  -v termote-data:/home/termote \
+  ghcr.io/lamngockhuong/termote:latest
+
+# Montar diretorio de workspace personalizado
+docker run -d --name termote -p 7680:7680 \
+  -v ~/projects:/workspace \
+  ghcr.io/lamngockhuong/termote:latest
+
+# Com Tailscale HTTPS (requer Tailscale no host)
+docker run -d --name termote -p 7680:7680 \
+  -e TERMOTE_USER=admin -e TERMOTE_PASS=secret \
+  ghcr.io/lamngockhuong/termote:latest
+sudo tailscale serve --bg --https=443 http://127.0.0.1:7680
+# Acesse em: https://your-hostname.tailnet-name.ts.net
+```
+
+### A Partir de Release
+
+```bash
+# Baixar release mais recente
+VERSION=$(curl -s https://api.github.com/repos/lamngockhuong/termote/releases/latest | grep tag_name | cut -d '"' -f4)
+wget https://github.com/lamngockhuong/termote/releases/download/${VERSION}/termote-${VERSION}.tar.gz
+tar xzf termote-${VERSION}.tar.gz
+cd termote-${VERSION#v}
+
+# Instalar (menu interativo ou com modo)
+./scripts/termote.sh install
+./scripts/termote.sh install container
+```
+
+### A Partir do Codigo Fonte
+
+```bash
+git clone https://github.com/lamngockhuong/termote.git
+cd termote
+./scripts/termote.sh install container
+```
+
+> **Nota**: `termote.sh` e a CLI unificada que suporta `install` (compila do fonte, usa artefatos pre-compilados quando disponiveis), `uninstall` e `health`.
+
+## Modos de Implantacao
+
+```mermaid
+flowchart LR
+    subgraph Container["Modo Container"]
+        direction TB
+        C1["Docker/Podman"] --> C2["tmux-api :7680"] --> C3["ttyd :7681"] --> C4["tmux"]
+    end
+
+    subgraph Native["Modo Nativo"]
+        direction TB
+        N1["Sistema Host"] --> N2["tmux-api :7680"] --> N3["ttyd :7681"] --> N4["tmux + Ferramentas do Host"]
+    end
+
+    User["Usuario"] --> Container & Native
+```
+
+| Modo          | Descricao        | Caso de Uso                               | Plataforma   |
+| ------------- | ---------------- | ----------------------------------------- | ------------ |
+| `--container` | Modo container   | Implantacao simples, ambiente isolado      | macOS, Linux |
+| `--native`    | Totalmente nativo | Acesso a ferramentas do host (claude, gh) | macOS, Linux |
+
+### Opcoes
+
+| Flag                        | Descricao                                            |
+| --------------------------- | ---------------------------------------------------- |
+| `--lan`                     | Expor na LAN (padrao: apenas localhost)              |
+| `--tailscale <host[:port]>` | Habilitar Tailscale HTTPS                            |
+| `--no-auth`                 | Desabilitar autenticacao basica                      |
+| `--port <port>`             | Porta do host (padrao: 7680, Windows: 7690)          |
+| `--fresh`                   | Forcar nova senha (ignorar config salva)             |
+| `--update`                  | Atualizar automaticamente com config salva           |
+| `--version <ver>`           | Instalar versao especifica (com ou sem `v`)          |
+
+| Variavel de Ambiente | Descricao                                            |
+| -------------------- | ---------------------------------------------------- |
+| `WORKSPACE`          | Diretorio do host para montar (padrao: `./workspace`) |
+| `TERMOTE_USER`       | Usuario de autenticacao (padrao: gerado automaticamente) |
+| `TERMOTE_PASS`       | Senha de autenticacao (padrao: gerada automaticamente)   |
+| `NO_AUTH`            | Defina como `true` para desabilitar autenticacao     |
+
+### Modo Container (recomendado pela simplicidade)
+
+Os scripts detectam automaticamente `podman` ou `docker` — ambos funcionam de forma identica.
+
+```bash
+./scripts/termote.sh install container             # localhost com basic auth
+./scripts/termote.sh install container --no-auth   # localhost sem auth
+./scripts/termote.sh install container --lan       # Acessivel pela LAN
+# Acesse: http://localhost:7680
+
+# Diretorio de workspace personalizado (montado em /workspace no container)
+WORKSPACE=~/projects ./scripts/termote.sh install container
+WORKSPACE=/path/to/code make install-container
+```
+
+> **Nota de seguranca**: Evite montar `$HOME` diretamente — diretorios sensiveis como `.ssh`, `.gnupg` ficarao acessiveis no container. Monte diretorios de projeto especificos.
+
+### Nativo (recomendado para acesso a binarios do host)
+
+Use quando precisar acessar binarios do host (claude, git, etc.):
+
+```bash
+# Linux
+sudo apt install ttyd tmux
+# Ou: sudo snap install ttyd
+./scripts/termote.sh install native
+
+# macOS
+brew install ttyd tmux go
+./scripts/termote.sh install native
+# Acesse: http://localhost:7680
+```
+
+### Com Tailscale HTTPS (todos os modos)
+
+Usa `tailscale serve` para HTTPS automatico (sem gerenciamento manual de certificados):
+
+```bash
+# Apenas Tailscale (porta padrao 443)
+./scripts/termote.sh install container --tailscale myhost.ts.net
+
+# Porta personalizada
+./scripts/termote.sh install native --tailscale myhost.ts.net:8765
+
+# Tailscale + acessivel pela LAN
+./scripts/termote.sh install container --tailscale myhost.ts.net --lan
+
+# Acesse: https://myhost.ts.net (ou :8765 para porta personalizada)
+```
+
+### Desinstalar
+
+```bash
+./scripts/termote.sh uninstall container   # Modo container
+./scripts/termote.sh uninstall native      # Modo nativo
+./scripts/termote.sh uninstall all         # Tudo
+```
+
+### Atualizacao
+
+```bash
+# Opcao 1: Atualizar automaticamente com config salva
+curl -fsSL .../get.sh | bash -s -- --update
+
+# Opcao 2: Executar novamente o one-liner (compara versoes, pergunta antes de instalar)
+curl -fsSL .../get.sh | bash
+
+# Opcao 3: Atualizacao manual
+./scripts/termote.sh uninstall [container|native]
+git pull origin main                    # Se instalado do codigo fonte
+./scripts/termote.sh install [container|native] [--lan] [--tailscale ...]
+```
+
+## Suporte a Plataformas
+
+| Plataforma | Container        | Nativo           | CLI Script  |
+| ---------- | ---------------- | ---------------- | ----------- |
+| Linux      | ✓                | ✓                | termote.sh  |
+| macOS      | ✓                | ✓                | termote.sh  |
+| Windows    | ⚠️ (experimental) | ⚠️ (experimental) | termote.ps1 |
+
+> **⚠️ Suporte ao Windows (Experimental)**: O suporte ao Windows esta em estagio inicial e precisa de mais testes. O modo container requer Docker Desktop, o modo nativo requer psmux. Por favor, reporte problemas no GitHub.
+
+### Modo Nativo Windows
+
+O modo nativo Windows usa [psmux](https://github.com/psmux/psmux) (multiplexador de terminal compativel com tmux para Windows):
+
+```powershell
+# Instalar psmux
+winget install psmux
+
+# Executar Termote
+.\scripts\termote.ps1 install native
+.\scripts\termote.ps1 install container  # Ou modo container com Docker Desktop
+```
+
+## Uso no Mobile
+
+| Acao               | Gesto               |
+| ------------------ | -------------------- |
+| Cancelar/interromper | Deslizar para esquerda (Ctrl+C) |
+| Tab completion     | Deslizar para direita |
+| Historico acima    | Deslizar para cima    |
+| Historico abaixo   | Deslizar para baixo   |
+| Colar              | Pressionar longo      |
+| Tamanho da fonte   | Pincar para dentro/fora |
+
+A barra de ferramentas virtual oferece: Tab, Esc, Ctrl, Shift, teclas de seta e combinacoes de teclas comuns. Suporta combinacoes Ctrl+Shift (colar, copiar). Alterne entre modo minimo e expandido para teclas adicionais (Home, End, Delete, etc.).
+
+## Estrutura do Projeto
+
+```
+termote/
+├── Makefile                # Comandos de build/test/deploy
+├── Dockerfile              # Modo Docker (tmux-api + ttyd)
+├── docker-compose.yml
+├── entrypoint.sh           # Entrypoint do Docker
+├── docs/                   # Documentacao
+│   └── images/screenshots/ # Capturas de tela do app
+├── pwa/                    # React PWA
+│   └── src/
+│       ├── components/
+│       ├── contexts/
+│       ├── hooks/
+│       ├── types/
+│       └── utils/
+├── tmux-api/               # Servidor Go
+│   ├── main.go             # Ponto de entrada
+│   ├── serve.go            # Servidor (PWA, proxy, auth)
+│   └── tmux.go             # Handlers da API tmux
+├── scripts/
+│   ├── termote.sh          # CLI Unix (install/uninstall/health)
+│   ├── termote.ps1         # CLI Windows PowerShell
+│   ├── get.sh              # Instalador online Unix (curl | bash)
+│   └── get.ps1             # Instalador online Windows (irm | iex)
+├── tests/                  # Suite de testes
+│   ├── test-termote.sh
+│   ├── test-termote.ps1    # Testes Windows
+│   ├── test-get.sh
+│   └── test-entrypoints.sh
+└── website/                # Site de docs Astro Starlight
+    └── src/content/docs/   # Documentacao MDX
+```
+
+## Desenvolvimento
+
+```bash
+make build          # Compilar PWA e tmux-api
+make test           # Executar todos os testes
+make health         # Verificar saude do servico
+make clean          # Parar containers
+
+# Testes E2E (requer servidor em execucao)
+./scripts/termote.sh install container  # Iniciar servidor primeiro
+cd pwa && pnpm test:e2e       # Executar testes Playwright
+cd pwa && pnpm test:e2e:ui    # Executar com UI debugger
+```
+
+**Teste Manual:** Veja a [Lista de Verificacao](docs/self-test-checklist.md)
+
+## Solucao de Problemas
+
+### Session nao persiste
+
+- Verifique o tmux: `tmux ls`
+- Confirme que o ttyd usa a flag `-A` (attach-or-create)
+
+### Erros de WebSocket
+
+- Verifique os logs do tmux-api: `docker logs termote`
+- Confirme que o ttyd esta rodando na porta 7681
+
+### Problemas com teclado no mobile
+
+- Certifique-se de que a meta tag viewport esta presente
+- Teste em um dispositivo real, nao em emulador
+
+### Modo nativo: processos nao iniciam
+
+```bash
+ps aux | grep ttyd         # Verificar se o ttyd esta rodando
+ps aux | grep tmux-api     # Verificar se o tmux-api esta rodando
+lsof -i :7680              # Confirmar que a porta esta em uso
+```
+
+## Notas de Seguranca
+
+- **Padrao: apenas localhost** - nao exposto na LAN a menos que a flag `--lan` seja usada
+- **Basic auth habilitado por padrao** - use `--no-auth` para desabilitar no dev local
+- **Protecao contra brute-force integrada** - rate limiting (5 tentativas/min por IP)
+- Use HTTPS (Tailscale) para producao
+- Restrinja a redes confiaveis/VPN
+
+## Licenca
+
+MIT

--- a/README.ru.md
+++ b/README.ru.md
@@ -1,0 +1,453 @@
+<p align="center">
+  <img src="pwa/public/banner-readme.svg" alt="Termote" width="600" />
+</p>
+
+<p align="center">
+  <a href="https://github.com/lamngockhuong/termote/releases"><img src="https://img.shields.io/github/v/release/lamngockhuong/termote?style=flat-square&color=blue" alt="Release" /></a>
+  <a href="https://github.com/lamngockhuong/termote/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/lamngockhuong/termote/ci.yml?branch=main&style=flat-square&label=CI" alt="CI" /></a>
+  <a href="https://github.com/lamngockhuong/termote/blob/main/LICENSE"><img src="https://img.shields.io/github/license/lamngockhuong/termote?style=flat-square" alt="License" /></a>
+  <a href="https://ghcr.io/lamngockhuong/termote"><img src="https://img.shields.io/badge/GHCR-termote-blue?style=flat-square&logo=github" alt="GHCR" /></a>
+  <a href="https://hub.docker.com/r/lamngockhuong/termote"><img src="https://img.shields.io/docker/pulls/lamngockhuong/termote?style=flat-square&logo=docker" alt="Docker Pulls" /></a>
+</p>
+
+<p align="center">
+  <img src="https://img.shields.io/badge/Go-1.21-00ADD8?style=flat-square&logo=go&logoColor=white" alt="Go" />
+  <img src="https://img.shields.io/badge/React-19-61DAFB?style=flat-square&logo=react&logoColor=black" alt="React" />
+  <img src="https://img.shields.io/badge/TypeScript-5.9-3178C6?style=flat-square&logo=typescript&logoColor=white" alt="TypeScript" />
+  <img src="https://img.shields.io/badge/PWA-ready-5A0FC8?style=flat-square&logo=pwa&logoColor=white" alt="PWA" />
+</p>
+
+<p align="center">
+  <a href="https://launch.j2team.dev/products/termote?utm_source=badge-launched&utm_medium=badge&utm_campaign=badge-termote" target="_blank" rel="noopener noreferrer"><img src="https://launch.j2team.dev/badge/termote/dark" alt="Termote - Launched on J2TEAM Launch" width="170" height="36" loading="lazy" /></a>
+  &nbsp;
+  <a href="https://unikorn.vn/p/termote?ref=embed-termote" target="_blank"><img src="https://unikorn.vn/api/widgets/badge/termote?theme=dark" alt="Termote trên Unikorn.vn" width="170" height="42" /></a>
+</p>
+
+Удалённое управление CLI-инструментами (Claude Code, GitHub Copilot, любой терминал) с мобильных устройств и десктопа через PWA.
+
+> **Termote** = Terminal + Remote
+>
+> 🇬🇧 [English](README.md) | 🇻🇳 [Tiếng Việt](README.vi.md) | 🇨🇳 [简体中文](README.zh-CN.md) | 🇯🇵 [日本語](README.ja.md) | 🇰🇷 [한국어](README.ko.md) | 🇪🇸 [Español](README.es.md) | 🇧🇷 [Português (BR)](README.pt-BR.md) | 🇫🇷 [Français](README.fr.md) | 🇩🇪 [Deutsch](README.de.md) | 🇮🇩 [Bahasa Indonesia](README.id.md)
+
+## Возможности
+
+- **Переключение сессий**: Множество tmux-сессий с созданием/редактированием/удалением
+- **Вкладки сессий**: Горизонтальная панель вкладок для быстрого переключения окон
+- **Мобильная адаптация**: Виртуальная клавиатура (Tab/Ctrl/Shift/стрелки, расширяемая)
+- **Поддержка жестов**: Свайп для Ctrl+C, Tab, навигации по истории
+- **История команд**: Вызов ранее отправленных команд с поиском
+- **Быстрые действия**: Плавающее меню для частых операций (clear, cancel, exit)
+- **Индикатор соединения**: Статус сервера в реальном времени с автоопределением разрыва
+- **Проверка обновлений**: Автоматическое уведомление о новой версии из GitHub releases
+- **PWA**: Устанавливается на домашний экран, работает офлайн
+- **Постоянные сессии**: tmux сохраняет сессии активными
+- **Сворачиваемая боковая панель**: Десктопный интерфейс с переключаемой боковой панелью сессий
+- **Полноэкранный режим**: Погружение в терминал на весь экран
+- **Сохранение конфигурации**: Автосохранение настроек установки с шифрованием пароля AES-256
+
+## Скриншоты
+
+<p align="center">
+  <img src="docs/images/screenshots/mobile-terminal.png" alt="Mobile Terminal" width="280" />
+  &nbsp;&nbsp;
+  <img src="docs/images/screenshots/mobile-sidebar.png" alt="Session Sidebar" width="280" />
+</p>
+
+## Архитектура
+
+```mermaid
+flowchart TB
+    subgraph Client["Клиент (Мобильный/Десктоп)"]
+        PWA["PWA - React + TypeScript"]
+        Gestures["Управление жестами"]
+        Keyboard["Виртуальная клавиатура"]
+    end
+
+    subgraph Server["tmux-api Server :7680"]
+        Static["Static Files"]
+        Proxy["WebSocket Proxy"]
+        API["REST API /api/tmux/*"]
+        Auth["Basic Auth"]
+    end
+
+    subgraph Backend["Backend Services"]
+        ttyd["ttyd :7681"]
+        tmux["tmux"]
+        Shell["Shell"]
+        Tools["CLI Tools"]
+    end
+
+    Gestures --> PWA
+    Keyboard --> PWA
+    PWA --> Static
+    PWA <--> Proxy
+    PWA --> API
+    Auth -.-> Static & Proxy & API
+    Proxy <--> ttyd
+    API --> tmux
+    ttyd --> tmux --> Shell --> Tools
+```
+
+## Быстрый старт
+
+> 📖 **Впервые используете Termote?** Ознакомьтесь с [Руководством по началу работы](docs/getting-started.md) для полного прохождения с примерами.
+
+```bash
+./scripts/termote.sh                   # Интерактивное меню
+./scripts/termote.sh install container # Контейнерный режим (docker/podman)
+./scripts/termote.sh install native    # Нативный режим (инструменты хоста)
+./scripts/termote.sh link              # Создать глобальную команду 'termote'
+make test                              # Запустить тесты
+```
+
+> После `link` используйте `termote` из любого места: `termote health`, `termote install native --lan`
+>
+> **Совет**: Установите [gum](https://github.com/charmbracelet/gum) для улучшенных интерактивных меню (опционально, есть fallback на bash)
+
+## Установка
+
+### Одной командой (рекомендуется)
+
+**macOS/Linux:**
+
+```bash
+# Скачать и спросить перед установкой (по умолчанию native mode)
+curl -fsSL https://raw.githubusercontent.com/lamngockhuong/termote/main/scripts/get.sh | bash
+
+# Автоустановка без запроса
+curl -fsSL .../get.sh | bash -s -- --yes
+
+# Только скачать (без установки)
+curl -fsSL .../get.sh | bash -s -- --download-only
+
+# Автообновление с сохранённой конфигурацией
+curl -fsSL .../get.sh | bash -s -- --update
+
+# Установить конкретную версию
+curl -fsSL .../get.sh | bash -s -- --version 0.0.4
+
+# С явным режимом и параметрами
+curl -fsSL .../get.sh | bash -s -- --yes --container --lan
+curl -fsSL .../get.sh | bash -s -- --yes --native --tailscale myhost
+
+# Принудительный ввод нового пароля (игнорировать сохранённую конфигурацию)
+curl -fsSL .../get.sh | bash -s -- --yes --container --fresh
+```
+
+**Windows (PowerShell):**
+
+> **Примечание:** Если выполнение скриптов отключено в вашей системе, сначала выполните:
+>
+> ```powershell
+> Set-ExecutionPolicy -Scope CurrentUser -ExecutionPolicy RemoteSigned
+> ```
+
+```powershell
+# Скачать и спросить перед установкой (по умолчанию native mode)
+irm https://raw.githubusercontent.com/lamngockhuong/termote/main/scripts/get.ps1 | iex
+
+# Автоустановка без запроса
+$env:TERMOTE_AUTO_YES = "true"; irm .../get.ps1 | iex
+
+# С явным режимом
+$env:TERMOTE_MODE = "container"; irm .../get.ps1 | iex
+
+# Автообновление с сохранённой конфигурацией
+$env:TERMOTE_UPDATE = "true"; irm .../get.ps1 | iex
+```
+
+### Docker
+
+```bash
+# Всё-в-одном (автогенерация учётных данных, смотрите логи: docker logs termote)
+docker run -d --name termote -p 7680:7680 ghcr.io/lamngockhuong/termote:latest
+
+# С пользовательскими учётными данными
+docker run -d --name termote -p 7680:7680 \
+  -e TERMOTE_USER=admin -e TERMOTE_PASS=secret \
+  ghcr.io/lamngockhuong/termote:latest
+
+# Без аутентификации (только для локальной разработки)
+docker run -d --name termote -p 7680:7680 \
+  -e NO_AUTH=true \
+  ghcr.io/lamngockhuong/termote:latest
+
+# С volume для сохранения данных
+docker run -d --name termote -p 7680:7680 \
+  -v termote-data:/home/termote \
+  ghcr.io/lamngockhuong/termote:latest
+
+# Монтирование пользовательской рабочей директории
+docker run -d --name termote -p 7680:7680 \
+  -v ~/projects:/workspace \
+  ghcr.io/lamngockhuong/termote:latest
+
+# С Tailscale HTTPS (требуется Tailscale на хосте)
+docker run -d --name termote -p 7680:7680 \
+  -e TERMOTE_USER=admin -e TERMOTE_PASS=secret \
+  ghcr.io/lamngockhuong/termote:latest
+sudo tailscale serve --bg --https=443 http://127.0.0.1:7680
+# Доступ по адресу: https://your-hostname.tailnet-name.ts.net
+```
+
+### Из релиза
+
+```bash
+# Скачать последний релиз
+VERSION=$(curl -s https://api.github.com/repos/lamngockhuong/termote/releases/latest | grep tag_name | cut -d '"' -f4)
+wget https://github.com/lamngockhuong/termote/releases/download/${VERSION}/termote-${VERSION}.tar.gz
+tar xzf termote-${VERSION}.tar.gz
+cd termote-${VERSION#v}
+
+# Установка (интерактивное меню или с указанием режима)
+./scripts/termote.sh install
+./scripts/termote.sh install container
+```
+
+### Из исходного кода
+
+```bash
+git clone https://github.com/lamngockhuong/termote.git
+cd termote
+./scripts/termote.sh install container
+```
+
+> **Примечание**: `termote.sh` — это единый CLI, поддерживающий `install` (сборка из исходников, использование готовых артефактов при наличии), `uninstall` и `health`.
+
+## Режимы развёртывания
+
+```mermaid
+flowchart LR
+    subgraph Container["Контейнерный режим"]
+        direction TB
+        C1["Docker/Podman"] --> C2["tmux-api :7680"] --> C3["ttyd :7681"] --> C4["tmux"]
+    end
+
+    subgraph Native["Нативный режим"]
+        direction TB
+        N1["Хост-система"] --> N2["tmux-api :7680"] --> N3["ttyd :7681"] --> N4["tmux + Инструменты хоста"]
+    end
+
+    User["Пользователь"] --> Container & Native
+```
+
+| Режим         | Описание            | Сценарий использования                      | Платформа    |
+| ------------- | ------------------- | ------------------------------------------- | ------------ |
+| `--container` | Контейнерный режим  | Простое развёртывание, изолированная среда   | macOS, Linux |
+| `--native`    | Полностью нативный  | Доступ к инструментам хоста (claude, gh)     | macOS, Linux |
+
+### Параметры
+
+| Флаг                        | Описание                                              |
+| --------------------------- | ----------------------------------------------------- |
+| `--lan`                     | Открыть доступ по LAN (по умолчанию: только localhost) |
+| `--tailscale <host[:port]>` | Включить Tailscale HTTPS                              |
+| `--no-auth`                 | Отключить базовую аутентификацию                       |
+| `--port <port>`             | Порт хоста (по умолчанию: 7680, Windows: 7690)        |
+| `--fresh`                   | Принудительный ввод нового пароля (игнорировать сохранённую конфигурацию) |
+| `--update`                  | Автообновление с сохранённой конфигурацией             |
+| `--version <ver>`           | Установить конкретную версию (с `v` или без)           |
+
+| Переменная окружения | Описание                                              |
+| -------------------- | ----------------------------------------------------- |
+| `WORKSPACE`          | Директория хоста для монтирования (по умолчанию: `./workspace`) |
+| `TERMOTE_USER`       | Имя пользователя для аутентификации (по умолчанию: автогенерация) |
+| `TERMOTE_PASS`       | Пароль для аутентификации (по умолчанию: автогенерация) |
+| `NO_AUTH`            | Установите `true` для отключения аутентификации        |
+
+### Контейнерный режим (рекомендуется для простоты)
+
+Скрипты автоматически определяют `podman` или `docker` — оба работают одинаково.
+
+```bash
+./scripts/termote.sh install container             # localhost с basic auth
+./scripts/termote.sh install container --no-auth   # localhost без аутентификации
+./scripts/termote.sh install container --lan       # Доступ по LAN
+# Доступ: http://localhost:7680
+
+# Пользовательская рабочая директория (монтируется в /workspace в контейнере)
+WORKSPACE=~/projects ./scripts/termote.sh install container
+WORKSPACE=/path/to/code make install-container
+```
+
+> **Примечание по безопасности**: Избегайте монтирования `$HOME` напрямую — конфиденциальные директории вроде `.ssh`, `.gnupg` будут доступны в контейнере. Монтируйте конкретные директории проектов.
+
+### Нативный режим (рекомендуется для доступа к бинарникам хоста)
+
+Используйте, когда нужен доступ к бинарникам хоста (claude, git и т.д.):
+
+```bash
+# Linux
+sudo apt install ttyd tmux
+# Или: sudo snap install ttyd
+./scripts/termote.sh install native
+
+# macOS
+brew install ttyd tmux go
+./scripts/termote.sh install native
+# Доступ: http://localhost:7680
+```
+
+### С Tailscale HTTPS (все режимы)
+
+Использует `tailscale serve` для автоматического HTTPS (без ручного управления сертификатами):
+
+```bash
+# Только Tailscale (порт по умолчанию 443)
+./scripts/termote.sh install container --tailscale myhost.ts.net
+
+# Пользовательский порт
+./scripts/termote.sh install native --tailscale myhost.ts.net:8765
+
+# Tailscale + доступ по LAN
+./scripts/termote.sh install container --tailscale myhost.ts.net --lan
+
+# Доступ: https://myhost.ts.net (или :8765 для пользовательского порта)
+```
+
+### Удаление
+
+```bash
+./scripts/termote.sh uninstall container   # Контейнерный режим
+./scripts/termote.sh uninstall native      # Нативный режим
+./scripts/termote.sh uninstall all         # Всё
+```
+
+### Обновление
+
+```bash
+# Способ 1: Автообновление с сохранённой конфигурацией
+curl -fsSL .../get.sh | bash -s -- --update
+
+# Способ 2: Повторный запуск one-liner (сравнивает версии, спрашивает перед установкой)
+curl -fsSL .../get.sh | bash
+
+# Способ 3: Ручное обновление
+./scripts/termote.sh uninstall [container|native]
+git pull origin main                    # Если установлено из исходного кода
+./scripts/termote.sh install [container|native] [--lan] [--tailscale ...]
+```
+
+## Поддержка платформ
+
+| Платформа | Container            | Native               | CLI-скрипт  |
+| --------- | -------------------- | -------------------- | ----------- |
+| Linux     | ✓                    | ✓                    | termote.sh  |
+| macOS     | ✓                    | ✓                    | termote.sh  |
+| Windows   | ⚠️ (экспериментально) | ⚠️ (экспериментально) | termote.ps1 |
+
+> **⚠️ Поддержка Windows (экспериментально)**: Поддержка Windows находится на ранней стадии и требует дополнительного тестирования. Контейнерный режим требует Docker Desktop, нативный режим требует psmux. Пожалуйста, сообщайте об ошибках на GitHub.
+
+### Нативный режим Windows
+
+Нативный режим Windows использует [psmux](https://github.com/psmux/psmux) (tmux-совместимый терминальный мультиплексор для Windows):
+
+```powershell
+# Установить psmux
+winget install psmux
+
+# Запустить Termote
+.\scripts\termote.ps1 install native
+.\scripts\termote.ps1 install container  # Или контейнерный режим с Docker Desktop
+```
+
+## Мобильное использование
+
+| Действие              | Жест                |
+| --------------------- | ------------------- |
+| Отмена/прерывание     | Свайп влево (Ctrl+C) |
+| Автодополнение Tab    | Свайп вправо        |
+| История вверх         | Свайп вверх         |
+| История вниз          | Свайп вниз          |
+| Вставка               | Долгое нажатие      |
+| Размер шрифта         | Щипок (увеличение/уменьшение) |
+
+Виртуальная панель инструментов предоставляет: Tab, Esc, Ctrl, Shift, клавиши-стрелки и часто используемые комбинации клавиш. Поддерживает комбинации Ctrl+Shift (вставка, копирование). Переключение между минимальным и расширенным режимом для дополнительных клавиш (Home, End, Delete и т.д.).
+
+## Структура проекта
+
+```
+termote/
+├── Makefile                # Команды build/test/deploy
+├── Dockerfile              # Docker mode (tmux-api + ttyd)
+├── docker-compose.yml
+├── entrypoint.sh           # Docker entrypoint
+├── docs/                   # Документация
+│   └── images/screenshots/ # Скриншоты приложения
+├── pwa/                    # React PWA
+│   └── src/
+│       ├── components/
+│       ├── contexts/
+│       ├── hooks/
+│       ├── types/
+│       └── utils/
+├── tmux-api/               # Go server
+│   ├── main.go             # Точка входа
+│   ├── serve.go            # Сервер (PWA, proxy, auth)
+│   └── tmux.go             # Обработчики tmux API
+├── scripts/
+│   ├── termote.sh          # Unix CLI (install/uninstall/health)
+│   ├── termote.ps1         # Windows PowerShell CLI
+│   ├── get.sh              # Unix онлайн-установщик (curl | bash)
+│   └── get.ps1             # Windows онлайн-установщик (irm | iex)
+├── tests/                  # Набор тестов
+│   ├── test-termote.sh
+│   ├── test-termote.ps1    # Windows тесты
+│   ├── test-get.sh
+│   └── test-entrypoints.sh
+└── website/                # Сайт документации Astro Starlight
+    └── src/content/docs/   # MDX-документация
+```
+
+## Разработка
+
+```bash
+make build          # Сборка PWA и tmux-api
+make test           # Запуск всех тестов
+make health         # Проверка состояния сервисов
+make clean          # Остановка контейнеров
+
+# E2E тесты (требуется запущенный сервер)
+./scripts/termote.sh install container  # Сначала запустите сервер
+cd pwa && pnpm test:e2e       # Запуск Playwright тестов
+cd pwa && pnpm test:e2e:ui    # Запуск с UI отладчиком
+```
+
+**Ручное тестирование:** См. [Чек-лист для самопроверки](docs/self-test-checklist.md)
+
+## Устранение неполадок
+
+### Сессия не сохраняется
+
+- Проверьте tmux: `tmux ls`
+- Убедитесь, что ttyd использует флаг `-A` (attach-or-create)
+
+### Ошибки WebSocket
+
+- Проверьте логи tmux-api: `docker logs termote`
+- Убедитесь, что ttyd работает на порту 7681
+
+### Проблемы с мобильной клавиатурой
+
+- Убедитесь в наличии viewport meta tag
+- Тестируйте на реальном устройстве, а не в эмуляторе
+
+### Нативный режим: процессы не запускаются
+
+```bash
+ps aux | grep ttyd         # Проверить, работает ли ttyd
+ps aux | grep tmux-api     # Проверить, работает ли tmux-api
+lsof -i :7680              # Убедиться, что порт используется
+```
+
+## Примечания по безопасности
+
+- **По умолчанию: только localhost** — не открывается в LAN без флага `--lan`
+- **Basic auth включён по умолчанию** — используйте `--no-auth` для отключения при локальной разработке
+- **Встроенная защита от брутфорса** — ограничение запросов (5 попыток/мин на IP)
+- Используйте HTTPS (Tailscale) для production
+- Ограничьте доступ доверенными сетями/VPN
+
+## Лицензия
+
+MIT

--- a/README.vi.md
+++ b/README.vi.md
@@ -27,7 +27,7 @@
 
 > **Termote** = Terminal + Remote
 >
-> [English](README.md)
+> 🇬🇧 [English](README.md) | 🇨🇳 [简体中文](README.zh-CN.md) | 🇯🇵 [日本語](README.ja.md) | 🇰🇷 [한국어](README.ko.md) | 🇪🇸 [Español](README.es.md) | 🇧🇷 [Português (BR)](README.pt-BR.md) | 🇫🇷 [Français](README.fr.md) | 🇩🇪 [Deutsch](README.de.md) | 🇷🇺 [Русский](README.ru.md) | 🇮🇩 [Bahasa Indonesia](README.id.md)
 
 ## Tính Năng
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,0 +1,453 @@
+<p align="center">
+  <img src="pwa/public/banner-readme.svg" alt="Termote" width="600" />
+</p>
+
+<p align="center">
+  <a href="https://github.com/lamngockhuong/termote/releases"><img src="https://img.shields.io/github/v/release/lamngockhuong/termote?style=flat-square&color=blue" alt="Release" /></a>
+  <a href="https://github.com/lamngockhuong/termote/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/lamngockhuong/termote/ci.yml?branch=main&style=flat-square&label=CI" alt="CI" /></a>
+  <a href="https://github.com/lamngockhuong/termote/blob/main/LICENSE"><img src="https://img.shields.io/github/license/lamngockhuong/termote?style=flat-square" alt="License" /></a>
+  <a href="https://ghcr.io/lamngockhuong/termote"><img src="https://img.shields.io/badge/GHCR-termote-blue?style=flat-square&logo=github" alt="GHCR" /></a>
+  <a href="https://hub.docker.com/r/lamngockhuong/termote"><img src="https://img.shields.io/docker/pulls/lamngockhuong/termote?style=flat-square&logo=docker" alt="Docker Pulls" /></a>
+</p>
+
+<p align="center">
+  <img src="https://img.shields.io/badge/Go-1.21-00ADD8?style=flat-square&logo=go&logoColor=white" alt="Go" />
+  <img src="https://img.shields.io/badge/React-19-61DAFB?style=flat-square&logo=react&logoColor=black" alt="React" />
+  <img src="https://img.shields.io/badge/TypeScript-5.9-3178C6?style=flat-square&logo=typescript&logoColor=white" alt="TypeScript" />
+  <img src="https://img.shields.io/badge/PWA-ready-5A0FC8?style=flat-square&logo=pwa&logoColor=white" alt="PWA" />
+</p>
+
+<p align="center">
+  <a href="https://launch.j2team.dev/products/termote?utm_source=badge-launched&utm_medium=badge&utm_campaign=badge-termote" target="_blank" rel="noopener noreferrer"><img src="https://launch.j2team.dev/badge/termote/dark" alt="Termote - Launched on J2TEAM Launch" width="170" height="36" loading="lazy" /></a>
+  &nbsp;
+  <a href="https://unikorn.vn/p/termote?ref=embed-termote" target="_blank"><img src="https://unikorn.vn/api/widgets/badge/termote?theme=dark" alt="Termote trên Unikorn.vn" width="170" height="42" /></a>
+</p>
+
+通过 PWA 从移动端/桌面端远程控制 CLI 工具（Claude Code、GitHub Copilot 及任何终端）。
+
+> **Termote** = Terminal + Remote
+>
+> 🇬🇧 [English](README.md) | 🇻🇳 [Tiếng Việt](README.vi.md) | 🇯🇵 [日本語](README.ja.md) | 🇰🇷 [한국어](README.ko.md) | 🇪🇸 [Español](README.es.md) | 🇧🇷 [Português (BR)](README.pt-BR.md) | 🇫🇷 [Français](README.fr.md) | 🇩🇪 [Deutsch](README.de.md) | 🇷🇺 [Русский](README.ru.md) | 🇮🇩 [Bahasa Indonesia](README.id.md)
+
+## 功能特性
+
+- **会话切换**：多个 tmux 会话，支持创建/编辑/删除
+- **会话标签**：水平标签栏，快速切换窗口
+- **移动端友好**：虚拟键盘工具栏（Tab/Ctrl/Shift/方向键，可展开）
+- **手势支持**：滑动执行 Ctrl+C、Tab、历史导航
+- **命令历史**：搜索并调用之前发送的命令
+- **快捷操作**：浮动菜单执行常用操作（clear、cancel、exit）
+- **连接指示器**：实时服务器状态，自动检测断开连接
+- **更新检查**：自动从 GitHub releases 通知新版本
+- **PWA**：可安装到主屏幕，支持离线使用
+- **持久会话**：tmux 保持会话存活
+- **可折叠侧边栏**：桌面端 UI 带可切换的会话侧边栏
+- **全屏模式**：沉浸式终端体验
+- **配置持久化**：自动保存安装设置，密码使用 AES-256 加密
+
+## 截图
+
+<p align="center">
+  <img src="docs/images/screenshots/mobile-terminal.png" alt="Mobile Terminal" width="280" />
+  &nbsp;&nbsp;
+  <img src="docs/images/screenshots/mobile-sidebar.png" alt="Session Sidebar" width="280" />
+</p>
+
+## 架构
+
+```mermaid
+flowchart TB
+    subgraph Client["客户端（移动端/桌面端）"]
+        PWA["PWA - React + TypeScript"]
+        Gestures["手势控制"]
+        Keyboard["虚拟键盘"]
+    end
+
+    subgraph Server["tmux-api Server :7680"]
+        Static["静态文件"]
+        Proxy["WebSocket 代理"]
+        API["REST API /api/tmux/*"]
+        Auth["Basic Auth"]
+    end
+
+    subgraph Backend["后端服务"]
+        ttyd["ttyd :7681"]
+        tmux["tmux"]
+        Shell["Shell"]
+        Tools["CLI 工具"]
+    end
+
+    Gestures --> PWA
+    Keyboard --> PWA
+    PWA --> Static
+    PWA <--> Proxy
+    PWA --> API
+    Auth -.-> Static & Proxy & API
+    Proxy <--> ttyd
+    API --> tmux
+    ttyd --> tmux --> Shell --> Tools
+```
+
+## 快速开始
+
+> 📖 **初次使用 Termote？** 请查看[入门指南](docs/getting-started.md)获取完整的操作步骤和示例。
+
+```bash
+./scripts/termote.sh                   # 交互式菜单
+./scripts/termote.sh install container # 容器模式（docker/podman）
+./scripts/termote.sh install native    # 原生模式（主机工具）
+./scripts/termote.sh link              # 创建 'termote' 全局命令
+make test                              # 运行测试
+```
+
+> `link` 之后，可在任何位置使用 `termote`：`termote health`、`termote install native --lan`
+
+> **提示**：安装 [gum](https://github.com/charmbracelet/gum) 可获得更美观的交互式菜单（可选，有 bash 回退方案）
+
+## 安装
+
+### 一行命令安装（推荐）
+
+**macOS/Linux：**
+
+```bash
+# 下载并在安装前询问确认（默认 native 模式）
+curl -fsSL https://raw.githubusercontent.com/lamngockhuong/termote/main/scripts/get.sh | bash
+
+# 自动安装，无需确认
+curl -fsSL .../get.sh | bash -s -- --yes
+
+# 仅下载（不安装）
+curl -fsSL .../get.sh | bash -s -- --download-only
+
+# 使用已保存的配置自动更新
+curl -fsSL .../get.sh | bash -s -- --update
+
+# 安装指定版本
+curl -fsSL .../get.sh | bash -s -- --version 0.0.4
+
+# 指定模式和选项
+curl -fsSL .../get.sh | bash -s -- --yes --container --lan
+curl -fsSL .../get.sh | bash -s -- --yes --native --tailscale myhost
+
+# 强制输入新密码（忽略已保存的配置）
+curl -fsSL .../get.sh | bash -s -- --yes --container --fresh
+```
+
+**Windows（PowerShell）：**
+
+> **注意：** 如果系统禁止运行脚本，请先执行以下命令：
+>
+> ```powershell
+> Set-ExecutionPolicy -Scope CurrentUser -ExecutionPolicy RemoteSigned
+> ```
+
+```powershell
+# 下载并在安装前询问确认（默认 native 模式）
+irm https://raw.githubusercontent.com/lamngockhuong/termote/main/scripts/get.ps1 | iex
+
+# 自动安装，无需确认
+$env:TERMOTE_AUTO_YES = "true"; irm .../get.ps1 | iex
+
+# 指定模式
+$env:TERMOTE_MODE = "container"; irm .../get.ps1 | iex
+
+# 使用已保存的配置自动更新
+$env:TERMOTE_UPDATE = "true"; irm .../get.ps1 | iex
+```
+
+### Docker
+
+```bash
+# 一体化部署（自动生成凭据，查看日志：docker logs termote）
+docker run -d --name termote -p 7680:7680 ghcr.io/lamngockhuong/termote:latest
+
+# 使用自定义凭据
+docker run -d --name termote -p 7680:7680 \
+  -e TERMOTE_USER=admin -e TERMOTE_PASS=secret \
+  ghcr.io/lamngockhuong/termote:latest
+
+# 无认证（仅限本地开发）
+docker run -d --name termote -p 7680:7680 \
+  -e NO_AUTH=true \
+  ghcr.io/lamngockhuong/termote:latest
+
+# 使用 volume 持久化数据
+docker run -d --name termote -p 7680:7680 \
+  -v termote-data:/home/termote \
+  ghcr.io/lamngockhuong/termote:latest
+
+# 挂载自定义 workspace 目录
+docker run -d --name termote -p 7680:7680 \
+  -v ~/projects:/workspace \
+  ghcr.io/lamngockhuong/termote:latest
+
+# 使用 Tailscale HTTPS（需要主机上安装 Tailscale）
+docker run -d --name termote -p 7680:7680 \
+  -e TERMOTE_USER=admin -e TERMOTE_PASS=secret \
+  ghcr.io/lamngockhuong/termote:latest
+sudo tailscale serve --bg --https=443 http://127.0.0.1:7680
+# 访问地址：https://your-hostname.tailnet-name.ts.net
+```
+
+### 从 Release 安装
+
+```bash
+# 下载最新 release
+VERSION=$(curl -s https://api.github.com/repos/lamngockhuong/termote/releases/latest | grep tag_name | cut -d '"' -f4)
+wget https://github.com/lamngockhuong/termote/releases/download/${VERSION}/termote-${VERSION}.tar.gz
+tar xzf termote-${VERSION}.tar.gz
+cd termote-${VERSION#v}
+
+# 安装（交互式菜单或指定模式）
+./scripts/termote.sh install
+./scripts/termote.sh install container
+```
+
+### 从源码安装
+
+```bash
+git clone https://github.com/lamngockhuong/termote.git
+cd termote
+./scripts/termote.sh install container
+```
+
+> **说明**：`termote.sh` 是统一的 CLI，支持 `install`（从源码构建，有预构建产物时使用预构建产物）、`uninstall` 和 `health` 命令。
+
+## 部署模式
+
+```mermaid
+flowchart LR
+    subgraph Container["容器模式"]
+        direction TB
+        C1["Docker/Podman"] --> C2["tmux-api :7680"] --> C3["ttyd :7681"] --> C4["tmux"]
+    end
+
+    subgraph Native["原生模式"]
+        direction TB
+        N1["主机系统"] --> N2["tmux-api :7680"] --> N3["ttyd :7681"] --> N4["tmux + 主机工具"]
+    end
+
+    User["用户"] --> Container & Native
+```
+
+| 模式          | 描述       | 使用场景                        | 平台         |
+| ------------- | ---------- | ------------------------------- | ------------ |
+| `--container` | 容器模式   | 简单部署，隔离环境              | macOS, Linux |
+| `--native`    | 全部原生   | 访问主机工具（claude、gh）      | macOS, Linux |
+
+### 选项
+
+| Flag                        | 描述                                           |
+| --------------------------- | ---------------------------------------------- |
+| `--lan`                     | 开放 LAN 访问（默认：仅 localhost）            |
+| `--tailscale <host[:port]>` | 启用 Tailscale HTTPS                           |
+| `--no-auth`                 | 禁用基本认证                                   |
+| `--port <port>`             | 主机端口（默认：7680，Windows：7690）          |
+| `--fresh`                   | 强制输入新密码（忽略已保存的配置）             |
+| `--update`                  | 使用已保存的配置自动更新                       |
+| `--version <ver>`           | 安装指定版本（带或不带 `v`）                   |
+
+| 环境变量       | 描述                                           |
+| -------------- | ---------------------------------------------- |
+| `WORKSPACE`    | 要挂载的主机目录（默认：`./workspace`）        |
+| `TERMOTE_USER` | 基本认证用户名（默认：自动生成）               |
+| `TERMOTE_PASS` | 基本认证密码（默认：自动生成）                 |
+| `NO_AUTH`      | 设为 `true` 以禁用认证                         |
+
+### 容器模式（推荐用于简单部署）
+
+脚本自动检测 `podman` 或 `docker` -- 两者使用方式完全相同。
+
+```bash
+./scripts/termote.sh install container             # localhost 带基本认证
+./scripts/termote.sh install container --no-auth   # localhost 无认证
+./scripts/termote.sh install container --lan       # LAN 可访问
+# 访问地址：http://localhost:7680
+
+# 自定义 workspace 目录（挂载到容器内的 /workspace）
+WORKSPACE=~/projects ./scripts/termote.sh install container
+WORKSPACE=/path/to/code make install-container
+```
+
+> **安全提示**：避免直接挂载 `$HOME` -- `.ssh`、`.gnupg` 等敏感目录将在容器中可访问。请挂载具体的项目目录。
+
+### 原生模式（推荐用于访问主机二进制文件）
+
+当需要访问主机二进制文件（claude、git 等）时使用：
+
+```bash
+# Linux
+sudo apt install ttyd tmux
+# 或：sudo snap install ttyd
+./scripts/termote.sh install native
+
+# macOS
+brew install ttyd tmux go
+./scripts/termote.sh install native
+# 访问地址：http://localhost:7680
+```
+
+### 使用 Tailscale HTTPS（所有模式）
+
+使用 `tailscale serve` 自动获取 HTTPS（无需手动管理证书）：
+
+```bash
+# 仅 Tailscale（默认端口 443）
+./scripts/termote.sh install container --tailscale myhost.ts.net
+
+# 自定义端口
+./scripts/termote.sh install native --tailscale myhost.ts.net:8765
+
+# Tailscale + LAN 可访问
+./scripts/termote.sh install container --tailscale myhost.ts.net --lan
+
+# 访问地址：https://myhost.ts.net（自定义端口则为 :8765）
+```
+
+### 卸载
+
+```bash
+./scripts/termote.sh uninstall container   # 容器模式
+./scripts/termote.sh uninstall native      # 原生模式
+./scripts/termote.sh uninstall all         # 全部
+```
+
+### 更新
+
+```bash
+# 方式一：使用已保存的配置自动更新
+curl -fsSL .../get.sh | bash -s -- --update
+
+# 方式二：重新运行一行命令（比较版本，安装前询问确认）
+curl -fsSL .../get.sh | bash
+
+# 方式三：手动更新
+./scripts/termote.sh uninstall [container|native]
+git pull origin main                    # 如果从源码安装
+./scripts/termote.sh install [container|native] [--lan] [--tailscale ...]
+```
+
+## 平台支持
+
+| 平台    | 容器模式           | 原生模式           | CLI 脚本    |
+| ------- | ------------------ | ------------------ | ----------- |
+| Linux   | ✓                  | ✓                  | termote.sh  |
+| macOS   | ✓                  | ✓                  | termote.sh  |
+| Windows | ⚠️ (实验性)        | ⚠️ (实验性)        | termote.ps1 |
+
+> **⚠️ Windows 支持（实验性）**：Windows 支持目前处于早期阶段，需要更多测试。容器模式需要 Docker Desktop，原生模式需要 psmux。如遇问题请在 GitHub 上反馈。
+
+### Windows 原生模式
+
+Windows 原生模式使用 [psmux](https://github.com/psmux/psmux)（兼容 tmux 的 Windows 终端复用器）：
+
+```powershell
+# 安装 psmux
+winget install psmux
+
+# 运行 Termote
+.\scripts\termote.ps1 install native
+.\scripts\termote.ps1 install container  # 或使用 Docker Desktop 的容器模式
+```
+
+## 移动端使用
+
+| 操作         | 手势                |
+| ------------ | ------------------- |
+| 取消/中断    | 左滑（Ctrl+C）      |
+| Tab 补全     | 右滑                |
+| 历史上翻     | 上滑                |
+| 历史下翻     | 下滑                |
+| 粘贴         | 长按                |
+| 字体大小     | 捏合缩放            |
+
+虚拟工具栏提供：Tab、Esc、Ctrl、Shift、方向键及常用组合键。支持 Ctrl+Shift 组合（粘贴、复制）。可在精简模式和展开模式之间切换以显示更多按键（Home、End、Delete 等）。
+
+## 项目结构
+
+```
+termote/
+├── Makefile                # 构建/测试/部署命令
+├── Dockerfile              # Docker 模式（tmux-api + ttyd）
+├── docker-compose.yml
+├── entrypoint.sh           # Docker 入口点
+├── docs/                   # 文档
+│   └── images/screenshots/ # 应用截图
+├── pwa/                    # React PWA
+│   └── src/
+│       ├── components/
+│       ├── contexts/
+│       ├── hooks/
+│       ├── types/
+│       └── utils/
+├── tmux-api/               # Go 服务端
+│   ├── main.go             # 入口点
+│   ├── serve.go            # 服务器（PWA、代理、认证）
+│   └── tmux.go             # tmux API 处理器
+├── scripts/
+│   ├── termote.sh          # Unix CLI（安装/卸载/健康检查）
+│   ├── termote.ps1         # Windows PowerShell CLI
+│   ├── get.sh              # Unix 在线安装器（curl | bash）
+│   └── get.ps1             # Windows 在线安装器（irm | iex）
+├── tests/                  # 测试套件
+│   ├── test-termote.sh
+│   ├── test-termote.ps1    # Windows 测试
+│   ├── test-get.sh
+│   └── test-entrypoints.sh
+└── website/                # Astro Starlight 文档站
+    └── src/content/docs/   # MDX 文档
+```
+
+## 开发
+
+```bash
+make build          # 构建 PWA 和 tmux-api
+make test           # 运行所有测试
+make health         # 检查服务健康状态
+make clean          # 停止容器
+
+# E2E 测试（需要运行中的服务器）
+./scripts/termote.sh install container  # 先启动服务器
+cd pwa && pnpm test:e2e       # 运行 Playwright 测试
+cd pwa && pnpm test:e2e:ui    # 使用 UI 调试器运行
+```
+
+**手动测试：** 参见[自测清单](docs/self-test-checklist.md)
+
+## 故障排除
+
+### 会话未持久化
+
+- 检查 tmux：`tmux ls`
+- 确认 ttyd 使用了 `-A` 参数（attach-or-create）
+
+### WebSocket 错误
+
+- 检查 tmux-api 日志：`docker logs termote`
+- 确认 ttyd 在端口 7681 上运行
+
+### 移动端键盘问题
+
+- 确保存在 viewport meta 标签
+- 在真机上测试，不要使用模拟器
+
+### 原生模式：进程未启动
+
+```bash
+ps aux | grep ttyd         # 检查 ttyd 是否在运行
+ps aux | grep tmux-api     # 检查 tmux-api 是否在运行
+lsof -i :7680              # 确认端口是否在使用
+```
+
+## 安全说明
+
+- **默认：仅 localhost** -- 除非使用 `--lan` 参数，否则不暴露到局域网
+- **默认启用基本认证** -- 使用 `--no-auth` 可为本地开发禁用
+- **内置暴力破解防护** -- 速率限制（每 IP 每分钟 5 次尝试）
+- 生产环境请使用 HTTPS（Tailscale）
+- 限制在受信任的网络/VPN 中使用
+
+## 许可证
+
+MIT


### PR DESCRIPTION
## Summary

- Add README translations for 9 new languages to support global developer communities
- Update language switcher with flag emojis across all 11 README files

### Languages added
| Flag | Language | File |
|------|----------|------|
| 🇨🇳 | 简体中文 (Chinese Simplified) | `README.zh-CN.md` |
| 🇯🇵 | 日本語 (Japanese) | `README.ja.md` |
| 🇰🇷 | 한국어 (Korean) | `README.ko.md` |
| 🇪🇸 | Español (Spanish) | `README.es.md` |
| 🇧🇷 | Português BR (Brazilian Portuguese) | `README.pt-BR.md` |
| 🇫🇷 | Français (French) | `README.fr.md` |
| 🇩🇪 | Deutsch (German) | `README.de.md` |
| 🇷🇺 | Русский (Russian) | `README.ru.md` |
| 🇮🇩 | Bahasa Indonesia (Indonesian) | `README.id.md` |

### What's translated
- Section headings, descriptions, table content, prose text
- Mermaid diagram display labels
- Code block comments

### What's preserved as-is
- All badges, images, URLs, code blocks, commands
- Technical terms (flags, env vars, CLI commands)
- Mermaid diagram node IDs and structure

## Test plan
- [x] Verify each README renders correctly on GitHub
- [x] Verify language switcher links work across all 11 files
- [x] Spot-check translation quality for each language