### PR TITLE
chore: migrate domain to termote.ohnice.app

### DIFF
--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -2,7 +2,7 @@ import { defineConfig } from "astro/config";
 import starlight from "@astrojs/starlight";
 
 export default defineConfig({
-  site: "https://termote.khuong.dev",
+  site: "https://termote.ohnice.app",
   integrations: [
     starlight({
       components: {

--- a/website/public/CNAME
+++ b/website/public/CNAME
@@ -1,1 +1,1 @@
-termote.khuong.dev
+termote.ohnice.app


### PR DESCRIPTION
## Summary
- Update Astro site URL: `termote.khuong.dev` → `termote.ohnice.app`
- Update GitHub Pages CNAME to new domain

## Test plan
- [ ] Configure DNS for `termote.ohnice.app` (CNAME → GitHub Pages)
- [ ] Verify GitHub Pages custom domain settings updated
- [ ] Confirm HTTPS certificate provisioned
- [ ] Validate site loads at new domain