### PR TITLE
ci: pin pnpm to 11.10.0 in workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
 
       - uses: pnpm/action-setup@v6
         with:
-          version: 11
+          version: 11.10.0
 
       - uses: actions/setup-node@v6
         with:
@@ -225,7 +225,7 @@ jobs:
 
       - uses: pnpm/action-setup@v6
         with:
-          version: 11
+          version: 11.10.0
 
       - uses: actions/setup-node@v6
         with:

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
         with:
-          version: 11
+          version: 11.10.0
 
       - name: Setup Node
         uses: actions/setup-node@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,7 +73,7 @@ jobs:
 
       - uses: pnpm/action-setup@v6
         with:
-          version: 11
+          version: 11.10.0
 
       - uses: actions/setup-node@v6
         with:


### PR DESCRIPTION
## Problem

Every pnpm CI job (Build PWA, Build Website, Release, Deploy) is currently failing at the `pnpm/action-setup@v6` step, before any project code runs:

```
Switching pnpm from v11.7.0 to v11.12.0...
[ERROR] Cannot use 'in' operator to search for 'integrity' in undefined
    at installPnpmToGlobalDir (...)
Something went wrong, self-installer exits with code 1
```

The workflows request `version: 11` (floating), so the action resolves to the latest 11.x at run time. **pnpm 11.12.0** has a regression that crashes during the action's global self-install. This blocks all pnpm jobs repo-wide, regardless of the change under test.

## Fix

Pin pnpm to the known-good **11.10.0** (verified locally) in all four `pnpm/action-setup@v6` usages:

- `.github/workflows/ci.yml` (Build PWA + Build Website)
- `.github/workflows/release.yml`
- `.github/workflows/deploy-website.yml`

## Follow-up

Once merged, the stuck dependency PRs go green on re-run (PR CI builds against `pull/N/merge`, so they inherit this pin automatically):

- #186 (jsdom 29.1.1)
- #187 (@playwright/test 1.61.1)
- #188 (@astrojs/starlight 0.41.3 + astro 7)
