### PR TITLE
ci: pin pnpm to 11.10.0 and stop Renovate bumping it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
 
       - uses: pnpm/action-setup@v6
         with:
-          version: 11.12.0
+          version: 11.10.0
 
       - uses: actions/setup-node@v6
         with:
@@ -225,7 +225,7 @@ jobs:
 
       - uses: pnpm/action-setup@v6
         with:
-          version: 11.12.0
+          version: 11.10.0
 
       - uses: actions/setup-node@v6
         with:

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
         with:
-          version: 11.12.0
+          version: 11.10.0
 
       - name: Setup Node
         uses: actions/setup-node@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,7 +73,7 @@ jobs:
 
       - uses: pnpm/action-setup@v6
         with:
-          version: 11.12.0
+          version: 11.10.0
 
       - uses: actions/setup-node@v6
         with:

--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,12 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
+  ],
+  "packageRules": [
+    {
+      "description": "Pin pnpm: 11.12.0 crashes pnpm/action-setup's global self-installer ('Cannot use in operator to search for integrity in undefined'), breaking every CI job. Re-enable once a fixed pnpm/action-setup release is available.",
+      "matchDepNames": ["pnpm"],
+      "enabled": false
+    }
   ]
 }


### PR DESCRIPTION
## Problem

My earlier pin (#189) set `pnpm/action-setup` to `version: 11.10.0`. Renovate manages that version as a `pnpm` dependency, so it immediately opened **#190 to bump it to 11.12.0**, which got merged.

pnpm **11.12.0** crashes the action's global self-installer, so `main` is now broken again — every pnpm CI job fails at setup:

```
version: 11.12.0
Switching pnpm from v11.7.0 to v11.12.0...
[ERROR] Cannot use 'in' operator to search for 'integrity' in undefined
    at installPnpmToGlobalDir
Something went wrong, self-installer exits with code 1
```

Verified in CI: `11.10.0` → `Switching ... to v11.10.0` → **pass**; `11.12.0` → **crash**.

## Fix

1. Revert pnpm to the known-good **11.10.0** in all four `pnpm/action-setup@v6` usages (`ci.yml` ×2, `release.yml`, `deploy-website.yml`).
2. Add a Renovate `packageRule` disabling `pnpm` updates, so it stops re-bumping to the broken version.

```json
{
  "matchDepNames": ["pnpm"],
  "enabled": false
}
```

Re-enable the rule once a `pnpm/action-setup` release ships that self-installs 11.12.0+ without crashing.

## Note

This supersedes the pin from #189 (which #190 reverted). Once merged, the open dependency PRs (#186 jsdom, #187 playwright) go green on re-run.
