### PR TITLE
docs: mark Windows support as stable

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -334,9 +334,9 @@ git pull origin main                    # Si se instalo desde codigo fuente
 | ---------- | ---------------- | ---------------- | ----------- |
 | Linux      | ✓                | ✓                | termote.sh  |
 | macOS      | ✓                | ✓                | termote.sh  |
-| Windows    | ⚠️ (experimental) | ⚠️ (experimental) | termote.ps1 |
+| Windows    | ✓                | ✓                | termote.ps1 |
 
-> **⚠️ Soporte de Windows (Experimental)**: El soporte de Windows esta actualmente en etapas tempranas y necesita mas pruebas. El modo container requiere Docker Desktop, el modo nativo requiere psmux. Por favor reporta problemas en GitHub.
+> **Soporte de Windows**: El modo container requiere Docker Desktop o Podman Desktop; el modo nativo requiere psmux. Por favor reporta cualquier problema en GitHub.
 
 ### Modo Nativo de Windows
 

--- a/README.es.md
+++ b/README.es.md
@@ -330,11 +330,11 @@ git pull origin main                    # Si se instalo desde codigo fuente
 
 ## Soporte de Plataformas
 
-| Plataforma | Container        | Nativo           | CLI Script  |
-| ---------- | ---------------- | ---------------- | ----------- |
-| Linux      | ✓                | ✓                | termote.sh  |
-| macOS      | ✓                | ✓                | termote.sh  |
-| Windows    | ✓                | ✓                | termote.ps1 |
+| Plataforma | Container | Nativo | CLI Script  |
+| ---------- | --------- | ------ | ----------- |
+| Linux      | ✓         | ✓      | termote.sh  |
+| macOS      | ✓         | ✓      | termote.sh  |
+| Windows    | ✓         | ✓      | termote.ps1 |
 
 > **Soporte de Windows**: El modo container requiere Docker Desktop o Podman Desktop; el modo nativo requiere psmux. Por favor reporta cualquier problema en GitHub.
 

--- a/README.md
+++ b/README.md
@@ -330,11 +330,11 @@ git pull origin main                    # If installed from source
 
 ## Platform Support
 
-| Platform | Container        | Native           | CLI Script  |
-| -------- | ---------------- | ---------------- | ----------- |
-| Linux    | ✓                | ✓                | termote.sh  |
-| macOS    | ✓                | ✓                | termote.sh  |
-| Windows  | ✓                | ✓                | termote.ps1 |
+| Platform | Container | Native | CLI Script  |
+| -------- | --------- | ------ | ----------- |
+| Linux    | ✓         | ✓      | termote.sh  |
+| macOS    | ✓         | ✓      | termote.sh  |
+| Windows  | ✓         | ✓      | termote.ps1 |
 
 > **Windows Support**: Container mode requires Docker Desktop or Podman Desktop; native mode requires psmux. Report any issues on GitHub.
 

--- a/README.md
+++ b/README.md
@@ -334,9 +334,9 @@ git pull origin main                    # If installed from source
 | -------- | ---------------- | ---------------- | ----------- |
 | Linux    | ✓                | ✓                | termote.sh  |
 | macOS    | ✓                | ✓                | termote.sh  |
-| Windows  | ⚠️ (experimental) | ⚠️ (experimental) | termote.ps1 |
+| Windows  | ✓                | ✓                | termote.ps1 |
 
-> **⚠️ Windows Support (Experimental)**: Windows support is currently in early stages and needs more testing. Container mode requires Docker Desktop, native mode requires psmux. Please report issues on GitHub.
+> **Windows Support**: Container mode requires Docker Desktop or Podman Desktop; native mode requires psmux. Report any issues on GitHub.
 
 ### Windows Native Mode
 

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -330,11 +330,11 @@ git pull origin main                    # Se instalado do codigo fonte
 
 ## Suporte a Plataformas
 
-| Plataforma | Container        | Nativo           | CLI Script  |
-| ---------- | ---------------- | ---------------- | ----------- |
-| Linux      | ✓                | ✓                | termote.sh  |
-| macOS      | ✓                | ✓                | termote.sh  |
-| Windows    | ✓                | ✓                | termote.ps1 |
+| Plataforma | Container | Nativo | CLI Script  |
+| ---------- | --------- | ------ | ----------- |
+| Linux      | ✓         | ✓      | termote.sh  |
+| macOS      | ✓         | ✓      | termote.sh  |
+| Windows    | ✓         | ✓      | termote.ps1 |
 
 > **Suporte ao Windows**: O modo container requer Docker Desktop ou Podman Desktop; o modo nativo requer psmux. Por favor, reporte qualquer problema no GitHub.
 

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -334,9 +334,9 @@ git pull origin main                    # Se instalado do codigo fonte
 | ---------- | ---------------- | ---------------- | ----------- |
 | Linux      | ✓                | ✓                | termote.sh  |
 | macOS      | ✓                | ✓                | termote.sh  |
-| Windows    | ⚠️ (experimental) | ⚠️ (experimental) | termote.ps1 |
+| Windows    | ✓                | ✓                | termote.ps1 |
 
-> **⚠️ Suporte ao Windows (Experimental)**: O suporte ao Windows esta em estagio inicial e precisa de mais testes. O modo container requer Docker Desktop, o modo nativo requer psmux. Por favor, reporte problemas no GitHub.
+> **Suporte ao Windows**: O modo container requer Docker Desktop ou Podman Desktop; o modo nativo requer psmux. Por favor, reporte qualquer problema no GitHub.
 
 ### Modo Nativo Windows
 

--- a/README.vi.md
+++ b/README.vi.md
@@ -328,11 +328,11 @@ git pull origin main                    # Nếu cài từ source
 
 ## Hỗ Trợ Nền Tảng
 
-| Nền Tảng | Container      | Native         | CLI Script  |
-| -------- | -------------- | -------------- | ----------- |
-| Linux    | ✓              | ✓              | termote.sh  |
-| macOS    | ✓              | ✓              | termote.sh  |
-| Windows  | ✓              | ✓              | termote.ps1 |
+| Nền Tảng | Container | Native | CLI Script  |
+| -------- | --------- | ------ | ----------- |
+| Linux    | ✓         | ✓      | termote.sh  |
+| macOS    | ✓         | ✓      | termote.sh  |
+| Windows  | ✓         | ✓      | termote.ps1 |
 
 > **Hỗ trợ Windows**: Chế độ container yêu cầu Docker Desktop hoặc Podman Desktop; chế độ native yêu cầu psmux. Vui lòng báo cáo lỗi trên GitHub nếu gặp sự cố.
 

--- a/README.vi.md
+++ b/README.vi.md
@@ -332,9 +332,9 @@ git pull origin main                    # Nếu cài từ source
 | -------- | -------------- | -------------- | ----------- |
 | Linux    | ✓              | ✓              | termote.sh  |
 | macOS    | ✓              | ✓              | termote.sh  |
-| Windows  | ⚠️ (thử nghiệm) | ⚠️ (thử nghiệm) | termote.ps1 |
+| Windows  | ✓              | ✓              | termote.ps1 |
 
-> **⚠️ Hỗ trợ Windows (Thử nghiệm)**: Hỗ trợ Windows hiện đang trong giai đoạn đầu và cần kiểm tra thêm. Chế độ container yêu cầu Docker Desktop, chế độ native yêu cầu psmux. Vui lòng báo cáo lỗi trên GitHub.
+> **Hỗ trợ Windows**: Chế độ container yêu cầu Docker Desktop hoặc Podman Desktop; chế độ native yêu cầu psmux. Vui lòng báo cáo lỗi trên GitHub nếu gặp sự cố.
 
 ### Chế Độ Native Windows
 

--- a/docs/codebase-summary.md
+++ b/docs/codebase-summary.md
@@ -331,7 +331,7 @@ Unified Unix CLI for installation, management, and updates:
 
 ### termote.ps1
 
-Windows PowerShell equivalent of `termote.sh` with same commands (planned, matches Unix behavior).
+Windows PowerShell equivalent of `termote.sh` with the same commands, at parity with Unix behavior (install, update, health, logs, link/unlink, menu).
 
 ### get.sh / get.ps1
 

--- a/docs/deployment-guide.md
+++ b/docs/deployment-guide.md
@@ -10,7 +10,7 @@
 | psmux         | -              | -                  | Required (`winget install psmux`) |
 | Go 1.21+      | -              | Required (build)   | Required (build)                  |
 
-> **⚠️ Windows Support (Experimental)**: Windows support is currently in early stages and needs more testing. Please report issues on GitHub.
+> **Windows Support**: Container mode requires Docker Desktop or Podman Desktop; native mode requires psmux + ttyd. Report any issues on GitHub.
 
 ## Deployment Modes
 

--- a/website/src/content/docs/getting-started.mdx
+++ b/website/src/content/docs/getting-started.mdx
@@ -18,10 +18,11 @@ import { Aside, Steps } from "@astrojs/starlight/components";
 - Docker Desktop or Podman Desktop (for Container mode — recommended)
 - or [psmux](https://github.com/psmux/psmux) + ttyd (for Native mode): `winget install psmux`
 
-<Aside type="caution" title="Experimental">
-  Windows support is currently experimental. Container mode is working. Native
-  mode has a known issue where ttyd crashes on Windows 11 (build 26200+) when a
-  WebSocket client connects — a fix is planned. Please report issues on
+<Aside type="tip" title="Windows">
+  Both Container and Native modes are fully supported on Windows. Native mode
+  ships an MSVC-built ttyd fork by default, which resolves the earlier crash on
+  Windows 11 (build 26200+); use `-Ttyd official` to opt into the upstream
+  build. Report any issues on
   [GitHub](https://github.com/lamngockhuong/termote/issues).
 </Aside>
 

--- a/website/src/content/docs/installation/native.mdx
+++ b/website/src/content/docs/installation/native.mdx
@@ -7,11 +7,11 @@ import { Steps, Tabs, TabItem, Aside } from "@astrojs/starlight/components";
 
 No Docker required. Access host binaries like `claude`, `git`, `gh`, etc.
 
-<Aside type="caution" title="Windows Native Mode — Known Issue">
-  On Windows 11 (build 26200+), ttyd.exe crashes when a WebSocket client
-  connects due to a ConPTY named pipe issue. A fix is planned (replacing ttyd
-  with a Go-based terminal handler). In the meantime, use **Container mode** on
-  Windows — it works correctly.
+<Aside type="tip" title="Windows Native Mode">
+  Native mode is fully supported on Windows. The install script auto-downloads
+  an MSVC-built ttyd fork by default, which resolves the earlier ConPTY crash on
+  Windows 11 (build 26200+). Pass `-Ttyd official` to use the upstream
+  `tsl0922/ttyd` build instead.
 </Aside>
 
 ## Prerequisites
@@ -35,9 +35,9 @@ No Docker required. Access host binaries like `claude`, `git`, `gh`, etc.
     # ttyd is auto-downloaded by the install script
     ```
 
-    <Aside type="caution">
-      Native mode on Windows is currently broken on Windows 11 build 26200+.
-      Use [Container mode](/installation/docker/) instead.
+    <Aside type="note">
+      ttyd is auto-downloaded by the install script (MSVC-built fork by
+      default). Use `-Ttyd official` for the upstream build.
     </Aside>
   </TabItem>
 </Tabs>

--- a/website/src/content/docs/vi/getting-started.mdx
+++ b/website/src/content/docs/vi/getting-started.mdx
@@ -18,11 +18,12 @@ import { Aside, Steps } from "@astrojs/starlight/components";
 - Docker Desktop hoặc Podman Desktop (cho chế độ Container — khuyến nghị)
 - hoặc [psmux](https://github.com/psmux/psmux) + ttyd (cho chế độ Native): `winget install psmux`
 
-<Aside type="caution" title="Thử nghiệm">
-  Hỗ trợ Windows đang trong giai đoạn thử nghiệm. Chế độ Container đã hoạt động.
-  Chế độ Native có lỗi đã biết: ttyd bị crash trên Windows 11 (build 26200+) khi
-  WebSocket client kết nối — bản sửa đang được lên kế hoạch. Vui lòng báo cáo lỗi
-  tại [GitHub](https://github.com/lamngockhuong/termote/issues).
+<Aside type="tip" title="Windows">
+  Cả chế độ Container và Native đều được hỗ trợ đầy đủ trên Windows. Chế độ
+  Native mặc định dùng bản ttyd fork build bằng MSVC, khắc phục lỗi crash trước
+  đây trên Windows 11 (build 26200+); dùng `-Ttyd official` để chuyển sang bản
+  upstream. Vui lòng báo cáo lỗi tại
+  [GitHub](https://github.com/lamngockhuong/termote/issues).
 </Aside>
 
 ## Cài đặt một dòng

--- a/website/src/content/docs/vi/installation/native.mdx
+++ b/website/src/content/docs/vi/installation/native.mdx
@@ -7,11 +7,11 @@ import { Steps, Tabs, TabItem, Aside } from "@astrojs/starlight/components";
 
 Không cần Docker. Truy cập binary host như `claude`, `git`, `gh`, v.v.
 
-<Aside type="caution" title="Windows Native — Lỗi đã biết">
-  Trên Windows 11 (build 26200+), ttyd.exe bị crash khi WebSocket client kết nối
-  do lỗi named pipe của ConPTY. Bản sửa đang được lên kế hoạch (thay thế ttyd
-  bằng terminal handler viết bằng Go). Trong thời gian chờ, hãy sử dụng **chế độ
-  Container** trên Windows — hoạt động bình thường.
+<Aside type="tip" title="Chế độ Native trên Windows">
+  Chế độ Native được hỗ trợ đầy đủ trên Windows. Script cài đặt mặc định tự động
+  tải bản ttyd fork build bằng MSVC, khắc phục lỗi crash ConPTY trước đây trên
+  Windows 11 (build 26200+). Dùng `-Ttyd official` để chuyển sang bản upstream
+  `tsl0922/ttyd`.
 </Aside>
 
 ## Yêu cầu
@@ -35,9 +35,9 @@ Không cần Docker. Truy cập binary host như `claude`, `git`, `gh`, v.v.
     # ttyd được tự động tải bởi script cài đặt
     ```
 
-    <Aside type="caution">
-      Chế độ Native trên Windows hiện đang bị lỗi trên Windows 11 build 26200+.
-      Hãy sử dụng [chế độ Container](/vi/installation/docker/) thay thế.
+    <Aside type="note">
+      ttyd được script cài đặt tự động tải (mặc định bản fork build bằng MSVC).
+      Dùng `-Ttyd official` để lấy bản upstream.
     </Aside>
   </TabItem>
 </Tabs>


### PR DESCRIPTION
## Summary

Windows container and native modes are production-ready — the CLI reached parity with Unix (install, update, health, logs, link/unlink, menu) and the default MSVC ttyd fork resolves the earlier Windows 11 (build 26200+) ConPTY crash. This PR removes the "experimental" framing from all docs.

## Changes

- **READMEs** (en, vi, es, pt-BR): Platform Support table Windows rows `⚠️ (experimental)` → `✓`; experimental warning replaced with a supported note (Docker Desktop **or** Podman Desktop for container mode).
- **docs/deployment-guide.md**: experimental warning → supported requirements note.
- **docs/codebase-summary.md**: `termote.ps1` no longer "(planned)" — documented at parity with Unix.
- **website getting-started** (en, vi): `caution "Experimental"` → `tip "Windows"`.
- **website installation/native** (en, vi): "Known Issue" caution → `tip`/`note` explaining the default fork ttyd; kept the factual rationale for `-Ttyd official`.

## Notes

Docs-only change. Kept the block explaining *why* the fork ttyd is the default (upstream `tsl0922/ttyd` Windows build still broken) since it justifies the `-Ttyd official` flag.
