### PR TITLE
chore: release 0.1.0

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -7,7 +7,6 @@
       "include-component-in-tag": false,
       "changelog-path": "CHANGELOG.md",
       "bump-minor-pre-major": true,
-      "bump-patch-for-minor-pre-major": true,
       "extra-files": [
         {
           "type": "json",


### PR DESCRIPTION
## Mục đích
Đưa Termote ra khỏi dải `0.0.x` lên bản chính thức đầu tiên **`0.1.0`** — app đã ổn định đa nền tảng (macOS/Linux/Windows).

## Thay đổi
1. **`release-please-config.json`**: bỏ `bump-patch-for-minor-pre-major` (giữ `bump-minor-pre-major`) → từ nay `feat:` bump **minor** (0.1.0 → 0.2.0), `fix:` bump patch, breaking bump minor. Đây là nhịp 0.x chuẩn cho dự án đã ra mắt.
2. **Commit rỗng `Release-As: 0.1.0`**: ép release-please mở PR release nhắm đúng `0.1.0` thay vì `0.0.17`.

## ⚠️ Khi merge (QUAN TRỌNG)
Repo dùng **squash-merge** → footer `Release-As` phải còn trong commit cuối trên `main`. Đảm bảo commit message khi squash **có dòng**:

```
Release-As: 0.1.0
```

Nếu dòng này bị mất, release-please sẽ chỉ tính ra `0.0.17`.

## Sau khi merge
- `release-please.yml` chạy → mở **release PR** cho `0.1.0` (cập nhật CHANGELOG, `pwa/package.json`, `scripts/termote.sh`, `scripts/termote.ps1`).
- Merge release PR đó → tạo tag `v0.1.0` → kích hoạt `release.yml` build & publish.